### PR TITLE
 REL - Release v1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,14 @@ veraPDF-parser
 [![Build Status](https://travis-ci.org/veraPDF/veraPDF-parser.svg?branch=integration)](https://travis-ci.org/veraPDF/parser "Travis-CI")
 [![Build Status](http://jenkins.openpreservation.org/buildStatus/icon?job=veraPDF-parser)](http://jenkins.openpreservation.org/job/veraPDF-parser/ "OPF Jenkins Release")
 [![Build Status](http://jenkins.openpreservation.org/buildStatus/icon?job=veraPDF-parser-dev)](http://jenkins.openpreservation.org/job/veraPDF-parser-dev/ "OPF Jenkins Development")
-[![Maven Central](https://img.shields.io/maven-central/v/org.verapdf/parser.svg)](http://repo1.maven.org/maven2/org/verapdf/pdf-model/ "Maven central")
+[![Maven Central](https://img.shields.io/maven-central/v/org.verapdf/parser.svg)](http://repo1.maven.org/maven2/org/verapdf/parser/ "Maven central")
 [![CodeCov Coverage](https://img.shields.io/codecov/c/github/veraPDF/veraPDF-parser.svg)](https://codecov.io/gh/veraPDF/veraPDF-parser/ "CodeCov coverage")
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/c0cab187a06a4820bc0891dd2bf8db85)](https://www.codacy.com/app/veraPDF/veraPDF-parser?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=veraPDF/veraPDF-parser&amp;utm_campaign=Badge_Grade "Codacy grade")
+
+[![GitHub issues](https://img.shields.io/github/issues/veraPDF/veraPDF-parser.svg)](https://github.com/veraPDF/veraPDF-parser/issues "Open issues on GitHub")
+[![GitHub issues](https://img.shields.io/github/issues-closed/veraPDF/veraPDF-parser.svg)](https://github.com/veraPDF/veraPDF-parser/issues-closed "Open issues on GitHub")
+[![GitHub issues](https://img.shields.io/github/issues-pr/veraPDF/veraPDF-parser.svg)](https://github.com/veraPDF/veraPDF-parser/issues-pr "Open issues on GitHub")
+[![GitHub issues](https://img.shields.io/github/issues-pr-closed/veraPDF/veraPDF-parser.svg)](https://github.com/veraPDF/veraPDF-parser/issues-pr-closed "Open issues on GitHub")
 
 Licensing
 ---------

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
     <groupId>org.verapdf</groupId>
     <artifactId>parser</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.10.0</version>
 
     <name>veraPDF Parser</name>
     <description>veraPDF tools for parsing, modifying and creating PDF documents.</description>

--- a/src/main/java/org/verapdf/as/filters/io/ASBufferedInFilter.java
+++ b/src/main/java/org/verapdf/as/filters/io/ASBufferedInFilter.java
@@ -361,7 +361,7 @@ public class ASBufferedInFilter extends ASInFilter {
         if (read < len) {
             // TODO: in fact, read may be less then len even if eof is not reached.
             // Fix problem for this case.
-            eod = offset + read;
+            eod = offset + (read == -1 ? 0 : read);
         }
     }
 

--- a/src/main/java/org/verapdf/parser/PDFParser.java
+++ b/src/main/java/org/verapdf/parser/PDFParser.java
@@ -143,7 +143,7 @@ public class PDFParser extends COSParser {
                 headerVersion = Float.parseFloat(headerParts[1]);
             }
         } catch (NumberFormatException e) {
-            LOGGER.log(Level.WARNING, "Can't parse the header version.", e);
+            LOGGER.log(Level.FINE, "Can't parse the document header.");
         }
 
         result.setVersion(headerVersion);
@@ -370,7 +370,7 @@ public class PDFParser extends COSParser {
                     if (postEOFDataSize > 0) {
                         if (buffer[currentBufferOffset + EOF_MARKER.length] == 0x0D) {
                             currentBufferOffset++;
-                            if (currentBufferOffset + EOF_MARKER.length < buffer.length && buffer[currentBufferOffset  + EOF_MARKER.length] == 0x0A) {
+                            if (currentBufferOffset + EOF_MARKER.length < buffer.length && buffer[currentBufferOffset + EOF_MARKER.length] == 0x0A) {
                                 postEOFDataSize -= 2;
                                 document.setPostEOFDataSize(postEOFDataSize);
                                 return;
@@ -468,16 +468,16 @@ public class PDFParser extends COSParser {
 
     private void parseXrefStream(final COSXRefInfo section) throws IOException {
         nextToken();
-        if(this.getToken().type != Token.Type.TT_INTEGER) {
+        if (this.getToken().type != Token.Type.TT_INTEGER) {
             throw new IOException("PDFParser::GetXRefSection(...)" + StringExceptions.CAN_NOT_LOCATE_XREF_TABLE);
         }
         nextToken();
-        if(this.getToken().type != Token.Type.TT_KEYWORD ||
+        if (this.getToken().type != Token.Type.TT_KEYWORD ||
                 this.getToken().keyword != Token.Keyword.KW_OBJ) {
             throw new IOException("PDFParser::GetXRefSection(...)" + StringExceptions.CAN_NOT_LOCATE_XREF_TABLE);
         }
         COSObject xrefCOSStream = getDictionary();
-        if(!(xrefCOSStream.getType() == COSObjType.COS_STREAM)) {
+        if (!(xrefCOSStream.getType() == COSObjType.COS_STREAM)) {
             throw new IOException("PDFParser::GetXRefSection(...)" + StringExceptions.CAN_NOT_LOCATE_XREF_TABLE);
         }
         XrefStreamParser xrefStreamParser = new XrefStreamParser(section, (COSStream) xrefCOSStream.getDirectBase());
@@ -509,7 +509,7 @@ public class PDFParser extends COSParser {
         }
 
         //we will skip eol marker in any case
-        source.seek(offset.intValue() - 1);
+        source.seek(offset.longValue() - 1);
 
 		COSXRefInfo section = new COSXRefInfo();
 		info.add(0, section);

--- a/src/main/java/org/verapdf/parser/PDFParser.java
+++ b/src/main/java/org/verapdf/parser/PDFParser.java
@@ -143,7 +143,7 @@ public class PDFParser extends COSParser {
                 headerVersion = Float.parseFloat(headerParts[1]);
             }
         } catch (NumberFormatException e) {
-            LOGGER.log(Level.FINE, "Can't parse the document header.");
+            LOGGER.log(Level.FINE, "Can't parse the document header.", e);
         }
 
         result.setVersion(headerVersion);

--- a/src/main/java/org/verapdf/tools/TypeConverter.java
+++ b/src/main/java/org/verapdf/tools/TypeConverter.java
@@ -43,6 +43,14 @@ public class TypeConverter {
 		if (toParse != null
 				&& toParse.startsWith("D:")) {
 
+			if (toParse.endsWith("'")) {
+				if (toParse.endsWith("''")) {
+					return getErrorDateFormat("Trailing apostrophe duplication");
+				} else {
+					toParse = toParse.substring(0, toParse.length() - 1);
+				}
+			}
+
 			if (!isDigits(toParse, 2, 4)) {
 				return getErrorDateFormat("Incorrect year data.");
 			}
@@ -115,7 +123,7 @@ public class TypeConverter {
 
 			if (length > 19) {
 				if (!"'".equals(toParse.substring(19, 20))) {
-					return getErrorDateFormat("Missing apostroph delimiter.");
+					return getErrorDateFormat("Missing apostrophe delimiter.");
 				}
 			}
 
@@ -127,14 +135,7 @@ public class TypeConverter {
 				}
 			}
 
-			// date format from PDF 1.4 spec
 			if (length > 22) {
-				if (!"'".equals(toParse.substring(22, 23))) {
-					return getErrorDateFormat("Incorrect ending.");
-				}
-			}
-
-			if (length > 23) {
 				return getErrorDateFormat("Incorrect ending.");
 			}
 


### PR DESCRIPTION
- fixed reading for buffered in filter;
- fixed pdf date parsing logic (accept trailing apostrophe);
- bumped minor -> 1.10 for release; and
- added some extra informational badges for PRs and issues.