### PR TITLE
Fixed creation of PD resources from resources dictionary in case of empty cos object

### DIFF
--- a/src/main/java/org/verapdf/factory/fonts/PDFontFactory.java
+++ b/src/main/java/org/verapdf/factory/fonts/PDFontFactory.java
@@ -50,7 +50,7 @@ public class PDFontFactory {
      * @return PDFont that corresponds to this dictionary.
      */
     public static PDFont getPDFont(COSObject fontDictionary) {
-        if (fontDictionary != null) {
+        if (fontDictionary != null && !fontDictionary.empty()) {
             if (fontDictionary.getType() == COSObjType.COS_DICT) {
                 COSDictionary dict = (COSDictionary) fontDictionary.getDirectBase();
                 ASAtom subtype = fontDictionary.getNameKey(ASAtom.SUBTYPE);
@@ -64,7 +64,6 @@ public class PDFontFactory {
                 } else if (subtype == ASAtom.TYPE0) {
                     return new PDType0Font(dict);
                 } else {
-                    LOGGER.log(Level.FINE, "Invalid value of Subtype in font dictionary");
                     return null;
                 }
             }

--- a/src/main/java/org/verapdf/pd/PDExtGState.java
+++ b/src/main/java/org/verapdf/pd/PDExtGState.java
@@ -81,14 +81,6 @@ public class PDExtGState extends PDResource {
         return getKey(ASAtom.CA_NS);
     }
 
-    public Double getCAValue() {
-        return getRealKey(ASAtom.CA);
-    }
-
-    public Double getCA_NSValue() {
-        return getRealKey(ASAtom.CA_NS);
-    }
-
     public COSName getCOSRenderingIntentName() {
         COSObject name = getKey(ASAtom.RI);
         if (name != null && name.getType() == COSObjType.COS_NAME) {

--- a/src/main/java/org/verapdf/pd/PDResources.java
+++ b/src/main/java/org/verapdf/pd/PDResources.java
@@ -108,6 +108,9 @@ public class PDResources extends PDObject {
 			return shadingMap.get(name);
 		}
 		COSObject rawShading = getResource(ASAtom.SHADING, name);
+		if (rawShading == null || rawShading.empty()) {
+			return null;
+		}
 		PDShading shading = new PDShading(rawShading, this);
 		shadingMap.put(name, shading);
 		return shading;
@@ -128,6 +131,9 @@ public class PDResources extends PDObject {
 			return extGStateMap.get(name);
 		}
 		COSObject rawExtGState = getResource(ASAtom.EXT_G_STATE, name);
+		if (rawExtGState == null || rawExtGState.empty()) {
+			return null;
+		}
 		PDExtGState extGState = new PDExtGState(rawExtGState);
 		extGStateMap.put(name, extGState);
 		return extGState;
@@ -148,6 +154,9 @@ public class PDResources extends PDObject {
 			return propertiesMap.get(name);
 		}
 		COSObject rawProperties = getResource(ASAtom.PROPERTIES, name);
+		if (rawProperties == null || rawProperties.empty()) {
+			return null;
+		}
 		PDResource properties = new PDResource(rawProperties);
 		propertiesMap.put(name, properties);
 		return properties;

--- a/src/main/java/org/verapdf/pd/images/PDXObject.java
+++ b/src/main/java/org/verapdf/pd/images/PDXObject.java
@@ -61,7 +61,7 @@ public abstract class PDXObject extends PDResource {
 	}
 
 	public static PDXObject getTypedPDXObject(COSObject object, PDResources resources) {
-		if (object != null) {
+		if (object != null && !object.empty()) {
 			ASAtom type = object.getNameKey(ASAtom.SUBTYPE);
 			if (ASAtom.IMAGE.equals(type)) {
 				return new PDXImage(object, resources);


### PR DESCRIPTION
fixes https://github.com/veraPDF/veraPDF-library/issues/1016