### PR TITLE
Fix #982, add Warning for file in #785

### DIFF
--- a/src/main/java/org/verapdf/pd/font/cmap/CMapParser.java
+++ b/src/main/java/org/verapdf/pd/font/cmap/CMapParser.java
@@ -290,7 +290,7 @@ public class CMapParser extends PSParser {
                 byte endRangeByte = endRange[i];
                 byte beginRangeByte = beginRange[i];
                 if (endRangeByte != beginRangeByte) {
-                    LOGGER.log(Level.FINE, "Incorrect bfrange in toUnicode CMap: " +
+                    LOGGER.log(Level.WARNING, "Incorrect bfrange in toUnicode CMap: " +
                             "bfrange contains more than 256 code.");
                 }
                 res += (beginRangeByte & 0x00FF) << ((endRange.length - i - 1) * 8);

--- a/src/main/java/org/verapdf/pd/font/cmap/ToUnicodeInterval.java
+++ b/src/main/java/org/verapdf/pd/font/cmap/ToUnicodeInterval.java
@@ -83,10 +83,7 @@ public class ToUnicodeInterval {
             return fffe;
         }
         try {
-            if (unicode[0] == 0) {
-                return String.valueOf((char)unicode[1]);
-            }
-            return new String(unicode, "UTF-16BE");
+            return  (unicode[0] == 0) ? String.valueOf(unicode[1]) : new String(unicode, "UTF-16BE");
         } catch (UnsupportedEncodingException e) {
             LOGGER.log(Level.FINE, "Can't find String encoding UTF-16BE", e);
             return null;    // I'm sure this won't be reached


### PR DESCRIPTION
Change Logger status from FINE to WARNING form incorrect bfrange in toUnicode CMap
getUnicodeNameFromLong() method fix
Closes https://github.com/veraPDF/veraPDF-library/issues/982