### PR TITLE
Fixed issue: #865 symbolic TrueType font validation

### DIFF
--- a/src/main/java/org/verapdf/pd/font/truetype/TrueTypeFontProgram.java
+++ b/src/main/java/org/verapdf/pd/font/truetype/TrueTypeFontProgram.java
@@ -84,15 +84,15 @@ public class TrueTypeFontProgram extends BaseTrueTypeProgram implements FontProg
             int gid = getGidFromCMaps(glyph);
             return gid >= 0 && gid < getNGlyphs();
         } else {
-            if (cMap30containsGlyph(code)) {
-                return true;
+            if (isCmapPresent(3, 0)) {
+                //No need to look at cmap(1, 0) if cmap(3, 0) exist
+                //GID 0 is considered to be .notdef
+                return cMap30containsGlyph(code) && getGIDFrom30(code) != 0;
             }
             TrueTypeCmapSubtable cmap10 = this.parser.getCmapTable(1, 0);
-            if (cmap10 != null) {
-                return cmap10.containsCID(code);
-            }
+            //GID 0 is considered to be .notdef
+            return cmap10 != null && cmap10.containsCID(code) && cmap10.getGlyph(code) != 0;
         }
-        return false;
     }
 
     /**


### PR DESCRIPTION
Symbolic TrueType font validation logic changed. Now subtable (1.0) is not checked if (3.0) presents. Moreover if glyph is mapped with GID 0 it means that this glyph is .notdef
Integration tests: passed.
Closes veraPDF/veraPDF-library/issues/865