### PR TITLE
Fixed issue: #968

### DIFF
--- a/src/main/java/org/verapdf/parser/PDFParser.java
+++ b/src/main/java/org/verapdf/parser/PDFParser.java
@@ -466,10 +466,38 @@ public class PDFParser extends COSParser {
                 }
                 xref.free = value.charAt(0);
                 xrefs.addEntry(number + i, xref);
+
+                checkXrefTableEntryLastBytes();
             }
             nextToken();
         }
         this.source.seekFromCurrentPosition(-7);
+    }
+
+    /**
+     * Checks that last bytes in the entry of Xref table should be:
+     * EOL(CRLF), or Space and LF, or Space and CR
+     *
+     * @throws IOException - incorrect reading from file
+     */
+    private void checkXrefTableEntryLastBytes() throws IOException {
+        byte ch = this.source.readByte();
+
+        if(isCR(ch)){
+            ch = this.source.readByte();
+            this.source.unread();
+            if(!isLF(ch)){
+                LOGGER.log(Level.WARNING, "Incorrect end of the line in cross-reference table.");
+            }
+            return;
+        } else if(ch == CharTable.ASCII_SPACE) {
+            ch = this.source.readByte();
+            if (isLF(ch) || isCR(ch)) {
+                return;
+            }
+        }
+
+        LOGGER.log(Level.WARNING, "Incorrect end of the line in cross-reference table.");
     }
 
     private void parseXrefStream(final COSXRefInfo section) throws IOException {


### PR DESCRIPTION
Added checking last bytes in cross-reference table entry.
In documentation says that at the end of the lines of cross-reference table can be only CRLF or spaceCR or spaceLF.
Passed integration tests.