### PR TITLE
Tokens are now built correctly on non-ASCII platforms

### DIFF
--- a/src/main/java/org/verapdf/parser/Token.java
+++ b/src/main/java/org/verapdf/parser/Token.java
@@ -21,6 +21,7 @@
 package org.verapdf.parser;
 
 import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
@@ -44,7 +45,13 @@ public class Token {
 
 	public void toKeyword() {
 		this.type = Type.TT_KEYWORD;
-		this.keyword = getKeyword(token.toString());
+
+		try {
+			this.keyword = getKeyword(token.toString("ISO-8859-1"));
+		} catch (UnsupportedEncodingException e) {
+			// cannot happen as ISO-8859-1 is required to be implemented in Java
+			this.keyword = getKeyword(token.toString());
+		}
 	}
 
 	public void append(int c) {


### PR DESCRIPTION
The veraPDF-parser assumes that it is running on an ASCII based platform and supplies no charset when building a Java string from the read bytes of the PDF (at least when building the PDF keywords from the read bytes).

This causes veraPDF to throw an Exception on z/OS when parsing the PDF file:

```
Caused by: java.io.IOException: PDFParser::GetXRefSection(...)can not locate xref table
   at org.verapdf.parser.PDFParser.parseXrefStream(PDFParser.java:513)
   at org.verapdf.parser.PDFParser.getXRefSectionAndTrailer(PDFParser.java:426)
   at org.verapdf.parser.PDFParser.getXRefInfo(PDFParser.java:554)
   at org.verapdf.parser.PDFParser.getXRefInfo(PDFParser.java:221)
   at org.verapdf.io.Reader.init(Reader.java:149)
   at org.verapdf.io.Reader.&lt;init>(Reader.java:72)
   at org.verapdf.cos.COSDocument.initReader(COSDocument.java:117)
   at org.verapdf.cos.COSDocument.&lt;init>(COSDocument.java:96)
   at org.verapdf.pd.PDDocument.&lt;init>(PDDocument.java:65)
   at org.verapdf.gf.model.GFModelParser.&lt;init>(GFModelParser.java:70)
   at org.verapdf.gf.model.GFModelParser.createModelWithFlavour(GFModelParser.java:93)
```

The root cause of this exception is that the bytes of the PDF are read and pushed into a ByteArrayOutputStream and later "toString()" is invoked on this ByteArrayOutputStream without specifying a charset. Then the default charset of the platform is used which is an EBCDIC based charset on z/OS (like IBM-500).



