### PR TITLE
Add setting default value for CFF {default|nominal}WidthX

### DIFF
--- a/src/main/java/org/verapdf/pd/font/cff/CFFFontBaseParser.java
+++ b/src/main/java/org/verapdf/pd/font/cff/CFFFontBaseParser.java
@@ -147,6 +147,8 @@ abstract class CFFFontBaseParser extends CFFFileBaseParser {
     }
 
     protected void readPrivateDictUnit() throws IOException {
+        this.defaultWidthX = 0; // default value
+        this.nominalWidthX = 0; // default value
         int next = this.source.peek() & 0xFF;
         if ((next > 27 && next < 31) || (next > 31 && next < 255)) {
             this.stack.add(readNumber());


### PR DESCRIPTION
This pull request fixes https://github.com/veraPDF/veraPDF-library/issues/1145 .

The default values for defaultWidthX and nominalWidthX in CFF are defined by Adobe's CFF specification, and if those values are not present in the font, it means they are the default values.
However, CFFFontBaseParser.java did not take into account those default values, and if the values did not exist in the font, they became an uninitialized value and the verapdf behavior became indetermination.

This commit solves the issue by initializing them with default values.