### PR TITLE
Feature/fewer temp files

### DIFF
--- a/src/main/java/org/verapdf/as/io/ASMemoryInStream.java
+++ b/src/main/java/org/verapdf/as/io/ASMemoryInStream.java
@@ -207,6 +207,17 @@ public class ASMemoryInStream extends SeekableInputStream {
         }
     }
 
+    @Override
+    public boolean markSupported() {
+        return true;
+    }
+
+
+    @Override
+    public synchronized void mark(int readlimit) {
+        resetPosition = currentPosition;
+    }
+
     /**
      * Resets stream.
      *

--- a/src/main/java/org/verapdf/as/io/ASMemoryInStream.java
+++ b/src/main/java/org/verapdf/as/io/ASMemoryInStream.java
@@ -281,4 +281,9 @@ public class ASMemoryInStream extends SeekableInputStream {
             throw new IOException();
         }
     }
+
+    @Override
+    public SeekableInputStream getSeekableStream(long startOffset, long length) throws IOException {
+        return new ASMemoryInStream(this, (int) startOffset, (int) length);
+    }
 }

--- a/src/main/java/org/verapdf/as/io/ASMemoryInStream.java
+++ b/src/main/java/org/verapdf/as/io/ASMemoryInStream.java
@@ -83,10 +83,16 @@ public class ASMemoryInStream extends SeekableInputStream {
     public ASMemoryInStream(ASMemoryInStream stream, int offset, int length) {
         this.buffer = stream.buffer;
         this.copiedBuffer = false;
-        this.bufferOffset = offset;
+        this.bufferOffset = offset + stream.bufferOffset;
+        if (this.bufferOffset < 0) {
+            throw new IllegalArgumentException("Range preceeds start of buffer");
+        }
+        if (this.bufferOffset + length > stream.bufferSize) {
+            throw new IllegalArgumentException("Range exceeds end of buffer");
+        }
         this.currentPosition = 0;
         this.resetPosition = this.currentPosition;
-        this.bufferSize = Math.min(stream.bufferSize, offset + length);
+        this.bufferSize = Math.min(stream.bufferSize, bufferOffset + length);
         this.numOfBufferUsers = stream.numOfBufferUsers;
         this.numOfBufferUsers.increment();
     }

--- a/src/main/java/org/verapdf/io/InternalInputStream.java
+++ b/src/main/java/org/verapdf/io/InternalInputStream.java
@@ -185,6 +185,9 @@ public class InternalInputStream extends SeekableInputStream {
 	@Override
 	public void seek(long offset) throws IOException {
 		checkClosed("Seeking");
+		if (offset < 0) {
+			throw new IOException("Can't seek for offset " + offset + " in InternalInputStream");
+		}
 		if (offset > this.getStreamLength()) {
 			throw new IllegalArgumentException("Destination offset is greater than stream length");
 		}

--- a/src/main/java/org/verapdf/io/InternalInputStream.java
+++ b/src/main/java/org/verapdf/io/InternalInputStream.java
@@ -215,7 +215,12 @@ public class InternalInputStream extends SeekableInputStream {
 		return new InternalInputStream(this.stream, fromOffset + startOffset, length, numOfFileUsers, filePath, isTempFile);
 	}
 
-	@Override
+    @Override
+    public SeekableInputStream getSeekableStream(long startOffset, long length) throws IOException {
+        return new InternalInputStream(this.stream, startOffset + fromOffset, length, numOfFileUsers, filePath, isTempFile);
+    }
+
+    @Override
 	public void closeResource() throws IOException {
 		if (!isSourceClosed) {
 			isSourceClosed = true;

--- a/src/main/java/org/verapdf/io/InternalInputStream.java
+++ b/src/main/java/org/verapdf/io/InternalInputStream.java
@@ -212,7 +212,7 @@ public class InternalInputStream extends SeekableInputStream {
 
 	@Override
 	public ASInputStream getStream(long startOffset, long length) throws IOException {
-		return new InternalInputStream(this.stream, startOffset, length, numOfFileUsers, filePath, isTempFile);
+		return new InternalInputStream(this.stream, fromOffset + startOffset, length, numOfFileUsers, filePath, isTempFile);
 	}
 
 	@Override

--- a/src/main/java/org/verapdf/io/InternalInputStream.java
+++ b/src/main/java/org/verapdf/io/InternalInputStream.java
@@ -49,6 +49,7 @@ public class InternalInputStream extends SeekableInputStream {
 	private String filePath;
 	private long fromOffset;
 	private long size;
+	private long resetPosition;
 
 	public InternalInputStream(final File file) throws IOException {
 		this(file, false);
@@ -166,9 +167,19 @@ public class InternalInputStream extends SeekableInputStream {
 	}
 
 	@Override
+	public boolean markSupported() {
+		return true;
+	}
+
+	@Override
+	public synchronized void mark(int readlimit) {
+		resetPosition = offset;
+	}
+
+	@Override
 	public void reset() throws IOException {
 		checkClosed("Reset");
-		this.seek(0);
+		this.seek(resetPosition);
 	}
 
 	@Override

--- a/src/main/java/org/verapdf/io/SeekableInputStream.java
+++ b/src/main/java/org/verapdf/io/SeekableInputStream.java
@@ -75,6 +75,8 @@ public abstract class SeekableInputStream extends ASInputStream {
      */
     public abstract ASInputStream getStream(long startOffset, long length) throws IOException;
 
+    public abstract SeekableInputStream getSeekableStream(long startOffset, long length) throws IOException;
+
     /**
      * {@inheritDoc}
      */
@@ -151,6 +153,14 @@ public abstract class SeekableInputStream extends ASInputStream {
      * @return SeekableStream that contains data of passed stream.
      */
     public static SeekableInputStream getSeekableStream(InputStream stream) throws IOException {
+        if (stream instanceof SeekableInputStream) {
+            SeekableInputStream seekableStream = (SeekableInputStream) stream;
+            long offset = seekableStream.getOffset();
+            long remaining = seekableStream.getStreamLength() - offset;
+            SeekableInputStream result = seekableStream.getSeekableStream(offset, remaining);
+            seekableStream.seekFromEnd(0);
+            return result;
+        }
         int totalRead = 0;
         byte[] buffer = new byte[0];
         byte[] temp = new byte[ASBufferedInFilter.BF_BUFFER_SIZE];

--- a/src/main/java/org/verapdf/pd/font/cff/CFFFileBaseParser.java
+++ b/src/main/java/org/verapdf/pd/font/cff/CFFFileBaseParser.java
@@ -55,6 +55,9 @@ class CFFFileBaseParser {
     }
 
     private long readOffset(int offSize) throws IOException {
+        if (offSize < 1) {
+            throw new IOException("Tried to read less than one byte");
+        }
         long res = 0;
         for (int i = 0; i < offSize - 1; ++i) {
             res |= (this.source.readByte() & 0xFF);
@@ -70,6 +73,9 @@ class CFFFileBaseParser {
             return new CFFIndex(0, 0, new int[0], new byte[0]);
         }
         int offSize = readCard8();
+        if (offSize == 0) {
+            throw new IOException("Bad offset size");
+        }
         int[] offset = new int[count + 1];
         for (int i = 0; i < count + 1; ++i) {
             offset[i] = (int) readOffset(offSize);

--- a/src/test/java/org/verapdf/io/ASMemoryInStreamTest.java
+++ b/src/test/java/org/verapdf/io/ASMemoryInStreamTest.java
@@ -24,8 +24,11 @@ import org.junit.Test;
 import org.verapdf.as.io.ASMemoryInStream;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ASMemoryInStreamTest {
 
@@ -80,6 +83,18 @@ public class ASMemoryInStreamTest {
         }
     }
 
+    @Test
+    public void shouldBeAbleToReadAllBytes() throws IOException {
+        byte buf[] = { 0, 1, 2 };
+        try (ASMemoryInStream stream = new ASMemoryInStream(buf)) {
+            for (int i = 0; i < buf.length; i++) {
+                byte b = stream.readByte();
+                assertEquals(i, b);
+            }
+            assertTrue(stream.isEOF());
+        }
+    }
+
     @Test(expected = IOException.class)
     public void shouldNotBeAbleToUnreadAtStart() throws IOException {
         try (ASMemoryInStream stream = new ASMemoryInStream(new byte[] { 0, 1, 2 })) {
@@ -94,6 +109,107 @@ public class ASMemoryInStreamTest {
             assertEquals(1, stream.read());
             stream.unread();
             assertEquals(1, stream.read());
+        }
+    }
+
+    @Test
+    public void shouldHaveCorrectPositionWhenNested() throws IOException {
+        try (
+            ASMemoryInStream a = new ASMemoryInStream("abc".getBytes(StandardCharsets.US_ASCII));
+        ) {
+            byte ba = a.readByte();
+            assertEquals('a', ba);
+            assertEquals(1, a.getOffset());
+            try (ASMemoryInStream b = (ASMemoryInStream) a.getStream(1, a.getStreamLength() - 1)) {
+                byte bb = b.readByte();
+                assertEquals('b', bb);
+                assertEquals(1, b.getOffset());
+            }
+        }
+    }
+
+    @Test
+    public void shouldHaveCorrectPositionWhenDoublyNested() throws IOException {
+        try (
+            ASMemoryInStream a = new ASMemoryInStream("abc".getBytes(StandardCharsets.US_ASCII));
+        ) {
+            byte ba = a.readByte();
+            assertEquals('a', ba);
+            assertEquals(1, a.getOffset());
+            assertEquals(3, a.getStreamLength());
+            assertFalse(a.isEOF());
+            try (ASMemoryInStream b = (ASMemoryInStream) a.getStream(1, a.getStreamLength() - 1)) {
+                byte bb = b.readByte();
+                assertEquals('b', bb);
+                assertEquals(1, b.getOffset());
+                assertEquals(2, b.getStreamLength());
+                assertFalse(b.isEOF());
+                try (ASMemoryInStream c = (ASMemoryInStream) b.getStream(1, b.getStreamLength() - 1)) {
+                    byte bc = c.readByte();
+                    assertEquals('c', bc);
+                    assertEquals(1, c.getOffset());
+                    assertEquals(1, c.getStreamLength());
+                    assertTrue(c.isEOF());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void shouldBeAbleToReadWhenDoublyNested() throws IOException {
+        byte[] buf = new byte[10 + 4];
+        byte[] deadbeef = new byte[] { (byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef };
+        for (int i = 0; i < 4; i++) {
+            buf[i] = deadbeef[i % deadbeef.length];
+        }
+        for (int i = 0; i < buf.length - 4; i++) {
+            buf[i + 4] = (byte) i;
+        }
+        try (ASMemoryInStream inner = new ASMemoryInStream(buf)) {
+            assertEquals(0xde, inner.read());
+            assertEquals(1, inner.getOffset());
+            assertEquals(0xad, inner.read());
+            assertEquals(2, inner.getOffset());
+            try (ASMemoryInStream outer =
+                (ASMemoryInStream) inner.getStream(2 + inner.getOffset(), inner.getStreamLength() - 4)) {
+
+                assertEquals(10, outer.getStreamLength());
+                for (int i = 0; i < 10; i++) {
+                    assertEquals(i, outer.getOffset());
+                    assertEquals(i, outer.readByte() & 0xff);
+                }
+                assertTrue(outer.isEOF());
+            }
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void sholdNotBeAbleToCreateSubstreamPastEnd() throws IOException {
+        byte[] buf = new byte[2];
+        try (ASMemoryInStream inner = new ASMemoryInStream(buf)) {
+            try (ASMemoryInStream outer = (ASMemoryInStream) new ASMemoryInStream(inner, 1, 2)) {
+            }
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void sholdNotBeAbleToCreateSubstreamBeforeStart() throws IOException {
+        byte[] buf = new byte[2];
+        try (ASMemoryInStream inner = new ASMemoryInStream(buf)) {
+            try (ASMemoryInStream outer = (ASMemoryInStream) new ASMemoryInStream(inner, -1, 2)) {
+            }
+        }
+    }
+
+    @Test
+    public void shouldBeAbleToCreateSubstreamBeforeStartOfOffsetSubstream() throws IOException {
+        byte[] buf = new byte[] {1, 2, 3};
+        try (ASMemoryInStream grandparent = new ASMemoryInStream(buf)) {
+            try (ASMemoryInStream parent = (ASMemoryInStream) new ASMemoryInStream(grandparent, 1, 2)) {
+                try (ASMemoryInStream child = (ASMemoryInStream) new ASMemoryInStream(parent, -1, 3)) {
+                    assertEquals(1, child.readByte() & 0xff);
+                }
+            }
         }
     }
 }

--- a/src/test/java/org/verapdf/io/ASMemoryInStreamTest.java
+++ b/src/test/java/org/verapdf/io/ASMemoryInStreamTest.java
@@ -1,0 +1,67 @@
+/**
+ * This file is part of veraPDF Parser, a module of the veraPDF project.
+ * Copyright (c) 2023, veraPDF Consortium <info@verapdf.org>
+ * All rights reserved.
+ *
+ * veraPDF Parser is free software: you can redistribute it and/or modify
+ * it under the terms of either:
+ *
+ * The GNU General public license GPLv3+.
+ * You should have received a copy of the GNU General Public License
+ * along with veraPDF Parser as the LICENSE.GPL file in the root of the source
+ * tree.  If not, see http://www.gnu.org/licenses/ or
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * The Mozilla Public License MPLv2+.
+ * You should have received a copy of the Mozilla Public License along with
+ * veraPDF Parser as the LICENSE.MPL file in the root of the source tree.
+ * If a copy of the MPL was not distributed with this file, you can obtain one at
+ * http://mozilla.org/MPL/2.0/.
+ */
+package org.verapdf.io;
+
+import org.junit.Test;
+import org.verapdf.as.io.ASMemoryInStream;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ASMemoryInStreamTest {
+
+    @Test
+    public void substreamOfStreamAtStartShouldReportCorrectOffset() throws IOException {
+        try (ASMemoryInStream stream = new ASMemoryInStream(new byte[] { 0, 1, 2 })) {
+            try (ASMemoryInStream copy = new ASMemoryInStream(stream, 0, 3)) {
+                assertEquals(0, copy.getOffset());
+            }
+        }
+    }
+
+    @Test
+    public void substreamOfStreamAtStartShouldReportCorrectLength() throws IOException {
+        try (ASMemoryInStream stream = new ASMemoryInStream(new byte[] { 0, 1, 2 })) {
+            try (ASMemoryInStream copy = new ASMemoryInStream(stream, 0, 3)) {
+                assertEquals(3, copy.getStreamLength());
+            }
+        }
+    }
+
+    @Test
+    public void substreamOfStreamAtOffsetShouldReportCorrectOffset() throws IOException {
+        try (ASMemoryInStream stream = new ASMemoryInStream(new byte[] { 0, 1, 2 })) {
+            try (ASMemoryInStream copy = new ASMemoryInStream(stream, 1, 2)) {
+                assertEquals(0, copy.getOffset());
+            }
+        }
+    }
+
+    @Test
+    public void substreamOfStreamAtOffsetShouldReportCorrectLength() throws IOException {
+        try (ASMemoryInStream stream = new ASMemoryInStream(new byte[] { 0, 1, 2 })) {
+            try (ASMemoryInStream copy = new ASMemoryInStream(stream, 1, 2)) {
+                assertEquals(2, copy.getStreamLength());
+            }
+        }
+    }
+}

--- a/src/test/java/org/verapdf/io/ASMemoryInStreamTest.java
+++ b/src/test/java/org/verapdf/io/ASMemoryInStreamTest.java
@@ -79,4 +79,21 @@ public class ASMemoryInStreamTest {
             assertEquals(1, stream.read());
         }
     }
+
+    @Test(expected = IOException.class)
+    public void shouldNotBeAbleToUnreadAtStart() throws IOException {
+        try (ASMemoryInStream stream = new ASMemoryInStream(new byte[] { 0, 1, 2 })) {
+            stream.unread();
+        }
+    }
+
+    @Test
+    public void shouldBeAbleToUnread() throws IOException {
+        try (ASMemoryInStream stream = new ASMemoryInStream(new byte[] { 0, 1, 2 })) {
+            assertEquals(0, stream.read());
+            assertEquals(1, stream.read());
+            stream.unread();
+            assertEquals(1, stream.read());
+        }
+    }
 }

--- a/src/test/java/org/verapdf/io/ASMemoryInStreamTest.java
+++ b/src/test/java/org/verapdf/io/ASMemoryInStreamTest.java
@@ -64,4 +64,19 @@ public class ASMemoryInStreamTest {
             }
         }
     }
+
+    @Test
+    public void shouldSupportMarkAndReset() throws IOException {
+        try (ASMemoryInStream stream = new ASMemoryInStream(new byte[] { 0, 1, 2 })) {
+
+            assertEquals(0, stream.read());
+            stream.mark(Integer.MAX_VALUE);
+
+            assertEquals(1, stream.read());
+            assertEquals(2, stream.read());
+
+            stream.reset();
+            assertEquals(1, stream.read());
+        }
+    }
 }

--- a/src/test/java/org/verapdf/io/InternalInputStreamTest.java
+++ b/src/test/java/org/verapdf/io/InternalInputStreamTest.java
@@ -1,0 +1,48 @@
+/**
+ * This file is part of veraPDF Parser, a module of the veraPDF project.
+ * Copyright (c) 2023, veraPDF Consortium <info@verapdf.org>
+ * All rights reserved.
+ *
+ * veraPDF Parser is free software: you can redistribute it and/or modify
+ * it under the terms of either:
+ *
+ * The GNU General public license GPLv3+.
+ * You should have received a copy of the GNU General Public License
+ * along with veraPDF Parser as the LICENSE.GPL file in the root of the source
+ * tree.  If not, see http://www.gnu.org/licenses/ or
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * The Mozilla Public License MPLv2+.
+ * You should have received a copy of the Mozilla Public License along with
+ * veraPDF Parser as the LICENSE.MPL file in the root of the source tree.
+ * If a copy of the MPL was not distributed with this file, you can obtain one at
+ * http://mozilla.org/MPL/2.0/.
+ */
+package org.verapdf.io;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.verapdf.as.io.ASMemoryInStream;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertEquals;
+
+public class InternalInputStreamTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void substreamOfStreamAtOffsetShouldReportCorrectOffset() throws IOException {
+        byte[] buf = new byte[] { 0 };
+        File file = temporaryFolder.newFile();
+        Files.write(file.toPath(), new byte[] { 1, 2, 3 });
+
+        try (InternalInputStream stream = InternalInputStream.createConcatenated(buf, Files.newInputStream(file.toPath()))) {
+            assertEquals(0, stream.getOffset());
+        }
+    }
+}

--- a/src/test/java/org/verapdf/io/InternalInputStreamTest.java
+++ b/src/test/java/org/verapdf/io/InternalInputStreamTest.java
@@ -64,4 +64,25 @@ public class InternalInputStreamTest {
             assertEquals(1, stream.read());
         }
     }
+
+    @Test(expected = IOException.class)
+    public void shouldNotBeAbleToUnreadAtStart() throws IOException {
+        File file = temporaryFolder.newFile();
+        Files.write(file.toPath(), new byte[] { 1, 2, 3 });
+        try (InternalInputStream stream = new InternalInputStream(file, true)) {
+            stream.unread();
+        }
+    }
+
+    @Test
+    public void shouldBeAbleToUnread() throws IOException {
+        File file = temporaryFolder.newFile();
+        Files.write(file.toPath(), new byte[] { 0, 1, 2 });
+        try (InternalInputStream stream = new InternalInputStream(file, true)) {
+            assertEquals(0, stream.read());
+            assertEquals(1, stream.read());
+            stream.unread();
+            assertEquals(1, stream.read());
+        }
+    }
 }

--- a/src/test/java/org/verapdf/io/InternalInputStreamTest.java
+++ b/src/test/java/org/verapdf/io/InternalInputStreamTest.java
@@ -45,4 +45,23 @@ public class InternalInputStreamTest {
             assertEquals(0, stream.getOffset());
         }
     }
+
+
+    @Test
+    public void shouldSupportMarkAndReset() throws IOException {
+        File file = temporaryFolder.newFile();
+        Files.write(file.toPath(), new byte[] { 0, 1,2 });
+
+        try (InternalInputStream stream = new InternalInputStream(file, true)) {
+
+            assertEquals(0, stream.read());
+            stream.mark(Integer.MAX_VALUE);
+
+            assertEquals(1, stream.read());
+            assertEquals(2, stream.read());
+
+            stream.reset();
+            assertEquals(1, stream.read());
+        }
+    }
 }

--- a/src/test/java/org/verapdf/io/SeekableInputStreamParametricTest.java
+++ b/src/test/java/org/verapdf/io/SeekableInputStreamParametricTest.java
@@ -1,0 +1,427 @@
+/**
+ * This file is part of veraPDF Parser, a module of the veraPDF project.
+ * Copyright (c) 2023, veraPDF Consortium <info@verapdf.org>
+ * All rights reserved.
+ *
+ * veraPDF Parser is free software: you can redistribute it and/or modify
+ * it under the terms of either:
+ *
+ * The GNU General public license GPLv3+.
+ * You should have received a copy of the GNU General Public License
+ * along with veraPDF Parser as the LICENSE.GPL file in the root of the source
+ * tree.  If not, see http://www.gnu.org/licenses/ or
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * The Mozilla Public License MPLv2+.
+ * You should have received a copy of the Mozilla Public License along with
+ * veraPDF Parser as the LICENSE.MPL file in the root of the source tree.
+ * If a copy of the MPL was not distributed with this file, you can obtain one at
+ * http://mozilla.org/MPL/2.0/.
+ */
+package org.verapdf.io;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.verapdf.as.io.ASInputStream;
+import org.verapdf.as.io.ASMemoryInStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests behaviour of SeekableInputStreams, build from different kinds of source streams.
+ *
+ * @author Magnus Reftel
+ */
+@RunWith(Parameterized.class)
+public class SeekableInputStreamParametricTest {
+    public static final int SMALL_INPUT_SIZE = 10;
+    public static final int LARGE_INPUT_SIZE = 15000;
+    private final int size;
+    private final InputStream input;
+
+    public SeekableInputStreamParametricTest(String unused, int size, StreamSupplier input) throws IOException {
+        this.size = size;
+        this.input = input.get();
+    }
+
+    @Parameters(name = "{0}")
+    public static List<Object[]> inputs() throws IOException {
+        return Arrays.asList(
+            new Object[] {
+                "small, memory", SMALL_INPUT_SIZE,
+                (StreamSupplier) () -> new ASMemoryInStream(buildBuffer(SMALL_INPUT_SIZE))
+            },
+            new Object[] {
+                "large, memory", LARGE_INPUT_SIZE,
+                (StreamSupplier) () -> new ASMemoryInStream(buildBuffer(LARGE_INPUT_SIZE))
+            },
+            new Object[] {
+                "small, internal", SMALL_INPUT_SIZE,
+                (StreamSupplier) () -> new InternalInputStream(buildFile(SMALL_INPUT_SIZE), true)
+            },
+            new Object[] {
+                "large, internal", LARGE_INPUT_SIZE,
+                (StreamSupplier) () -> new InternalInputStream(buildFile(LARGE_INPUT_SIZE), true)
+            },
+            new Object[] {
+                "small, memory, at offset", SMALL_INPUT_SIZE,
+                (StreamSupplier) () -> withOffset(4, new ASMemoryInStream(buildOffsetBuffer(4, SMALL_INPUT_SIZE)))
+            },
+            new Object[] {
+                "large, memory, at offset", LARGE_INPUT_SIZE,
+                (StreamSupplier) () -> withOffset(4, new ASMemoryInStream(buildOffsetBuffer(4, LARGE_INPUT_SIZE)))
+            },
+            new Object[] {
+                "small, internal, at offset", SMALL_INPUT_SIZE,
+                (StreamSupplier) () -> withOffset(4, new InternalInputStream(buildOffsetFile(4, SMALL_INPUT_SIZE), true))
+            },
+            new Object[] {
+                "large, internal, at offset", LARGE_INPUT_SIZE,
+                (StreamSupplier) () -> withOffset(4, new InternalInputStream(buildOffsetFile(4, LARGE_INPUT_SIZE), true))
+            },
+            new Object[] {
+                "small, memory, nested", SMALL_INPUT_SIZE,
+                (StreamSupplier) () -> nestedAtOffset(4, withOffset(2, new ASMemoryInStream(buildOffsetBuffer(4, SMALL_INPUT_SIZE))))
+            },
+            new Object[] {
+                "large, memory, nested", LARGE_INPUT_SIZE,
+                (StreamSupplier) () -> nestedAtOffset(4, withOffset(2, new ASMemoryInStream(buildOffsetBuffer(4, LARGE_INPUT_SIZE))))
+            },
+            new Object[] {
+                "small, internal, nested", SMALL_INPUT_SIZE,
+                (StreamSupplier) () -> nestedAtOffset(4, withOffset(2, new InternalInputStream(buildOffsetFile(4, SMALL_INPUT_SIZE), true)))
+            },
+            new Object[] {
+                "large, internal, nested", LARGE_INPUT_SIZE,
+                (StreamSupplier) () -> nestedAtOffset(4, withOffset(2, new InternalInputStream(buildOffsetFile(4, LARGE_INPUT_SIZE), true)))
+            },
+            new Object[] {
+                "small, other", SMALL_INPUT_SIZE,
+                (StreamSupplier) () -> new ByteArrayInputStream(buildBuffer(SMALL_INPUT_SIZE))
+            },
+            new Object[] {
+                "large, other", LARGE_INPUT_SIZE,
+                (StreamSupplier) () -> new ByteArrayInputStream(buildBuffer(LARGE_INPUT_SIZE))
+            }
+        );
+    }
+
+    private static <T extends InputStream> T withOffset(int offset, T in) throws IOException {
+        byte[] buf = new byte[offset];
+        assertEquals(offset, in.read(buf));
+        return in;
+    }
+
+    private static ASInputStream nestedAtOffset(int offset, SeekableInputStream in) throws IOException {
+        return in.getStream(offset, in.getStreamLength() - offset);
+    }
+
+    interface StreamSupplier {
+        InputStream get() throws IOException;
+    }
+
+    private static byte[] buildBuffer(int size) {
+        byte[] buf = new byte[size];
+        for (int i = 0; i < buf.length; i++) {
+            buf[i] = (byte) i;
+        }
+        return buf;
+    }
+
+    private static byte[] buildOffsetBuffer(int offset, int size) {
+        byte[] buf = new byte[size + offset];
+        byte[] deadbeef = new byte[] {(byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef};
+        for (int i = 0; i < offset; i++) {
+            buf[i] = deadbeef[offset % deadbeef.length];
+        }
+        for (int i = 0; i < buf.length - offset; i++) {
+            buf[i + offset] = (byte) i;
+        }
+        return buf;
+    }
+
+    private static File buildFile(int size) throws IOException {
+        Path path = Files.createTempFile("test", "bin");
+        path.toFile().deleteOnExit();
+        try (OutputStream out = Files.newOutputStream(path)) {
+            for (int i = 0; i < size; i++) {
+                out.write((byte) i);
+            }
+        }
+        return path.toFile();
+    }
+
+    private static File buildOffsetFile(int offset, int size) throws IOException {
+        Path path = Files.createTempFile("test", "bin");
+        path.toFile().deleteOnExit();
+        try (OutputStream out = Files.newOutputStream(path)) {
+            byte[] deadbeef = new byte[] {(byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef};
+            for (int i = 0; i < offset; i++) {
+                out.write(deadbeef[i % deadbeef.length]);
+            }
+            for (int i = 0; i < size; i++) {
+                out.write((byte) i);
+            }
+        }
+        return path.toFile();
+    }
+
+    @Test
+    public void seekableStreamShouldHaveSameContentsAsOriginal() throws IOException {
+        input.mark(Integer.MAX_VALUE);
+        try (
+            SeekableInputStream seekable = SeekableInputStream.getSeekableStream(input);
+        ) {
+            input.reset();
+            while (true) {
+                int a = input.read();
+                int b = seekable.read();
+                assertEquals(a, b);
+                if (a == -1) {
+                    break;
+                }
+            }
+        }
+    }
+
+    @Test
+    public void closingTheOriginalStreamDoesNotCloseASeekableStreamBasedOnIt() throws IOException {
+        try (
+            SeekableInputStream seekable = SeekableInputStream.getSeekableStream(input);
+        ) {
+            input.close();
+            assertEquals(0, seekable.read());
+            assertEquals(1, seekable.read());
+        }
+    }
+
+    @Test
+    public void closingASeekableStreamDoesNotCloseTheStreamItIsBasedOn() throws IOException {
+        input.mark(Integer.MAX_VALUE);
+        try (
+            SeekableInputStream seekable = SeekableInputStream.getSeekableStream(input);
+        ) {
+            input.reset();
+            seekable.close();
+            assertEquals(0, input.read());
+        }
+    }
+
+    @Test
+    public void creatingSeekableStreamShouldConsumeOriginal() throws IOException {
+        try (
+            SeekableInputStream seekable = SeekableInputStream.getSeekableStream(input);
+        ) {
+            assertEquals(-1, input.read());
+            assertEquals(0, seekable.read());
+        }
+    }
+
+    @Test
+    public void creatingSeekableStreamFromSeekableShouldConsumeIntermediary() throws IOException {
+        try (
+            SeekableInputStream seekable1 = SeekableInputStream.getSeekableStream(input);
+            SeekableInputStream seekable2 = SeekableInputStream.getSeekableStream(seekable1);
+        ) {
+            assertEquals(-1, seekable1.read());
+            assertEquals(0, seekable2.read());
+        }
+    }
+
+    @Test
+    public void seekableStreamsShouldBePositionedAtTheCurrentPositionOfTheSource() throws IOException {
+        for (int i = 0; i < 5; i++) {
+            input.read();
+        }
+        try (
+            SeekableInputStream seekable = SeekableInputStream.getSeekableStream(input);
+        ) {
+            assertEquals(5, seekable.read());
+            assertEquals(6, seekable.read());
+        }
+    }
+
+    @Test
+    public void shouldReportCorrectLengthWhenCreatedFromStreamAtStart() throws IOException {
+        try (
+            SeekableInputStream seekable = SeekableInputStream.getSeekableStream(input);
+        ) {
+            assertEquals(size, seekable.getStreamLength());
+        }
+    }
+
+    @Test
+    public void shouldReportCorrectLengthWhenCreatedFromStreamAtOffset() throws IOException {
+        input.read();
+        try (
+            SeekableInputStream seekable = SeekableInputStream.getSeekableStream(input);
+        ) {
+            assertEquals(size - 1, seekable.getStreamLength());
+        }
+    }
+
+    @Test
+    public void shouldReportCorrectPositionAfterSmallRead() throws IOException {
+        try (
+            SeekableInputStream seekable = SeekableInputStream.getSeekableStream(input);
+        ) {
+            byte buf[] = new byte[SMALL_INPUT_SIZE - 1];
+
+            assertEquals(0, seekable.getOffset());
+
+            int read = seekable.read();
+            assertEquals(0, read);
+            assertEquals(1, seekable.getOffset());
+
+            int numRead = seekable.read(buf);
+            assertEquals(buf.length, numRead);
+            assertEquals(buf.length + 1, seekable.getOffset());
+        }
+    }
+
+    @Test
+    public void shouldReportCorrectPositionAfterLargeRead() throws IOException {
+        if (size < LARGE_INPUT_SIZE) {  // Skip this test for small inputs
+            return;
+        }
+        try (
+            SeekableInputStream seekable = SeekableInputStream.getSeekableStream(input);
+        ) {
+            byte buf[] = new byte[LARGE_INPUT_SIZE - 1];
+
+            assertEquals(0, seekable.getOffset());
+
+            int read = seekable.read();
+            assertEquals(0, read);
+            assertEquals(1, seekable.getOffset());
+
+            int numRead = seekable.read(buf);
+            if (numRead >= buf.length) {
+                assertEquals(buf.length, numRead);
+                assertEquals(buf.length + 1, seekable.getOffset());
+            }
+        }
+    }
+
+    @Test
+    public void shouldReportCorrectPositionAfterAbsoluteSeek() throws IOException {
+        try (
+            SeekableInputStream seekable = SeekableInputStream.getSeekableStream(input);
+        ) {
+            assertEquals(0, seekable.getOffset());
+
+            seekable.seek(5);
+            assertEquals(5, seekable.getOffset());
+        }
+    }
+
+    @Test
+    public void shouldReportCorrectPositionAfterAbsoluteSeekWhenInputIsAtAnOffset() throws IOException {
+        input.read();
+        try (
+            SeekableInputStream seekable = SeekableInputStream.getSeekableStream(input);
+        ) {
+            assertEquals(0, seekable.getOffset());
+
+            seekable.seek(5);
+            assertEquals(5, seekable.getOffset());
+        }
+    }
+
+    @Test
+    public void shouldReportCorrectPositionAfterRelativeSeek() throws IOException {
+        try (
+            SeekableInputStream seekable = SeekableInputStream.getSeekableStream(input);
+        ) {
+            assertEquals(0, seekable.getOffset());
+
+            seekable.seekFromCurrentPosition(5);
+            assertEquals(5, seekable.getOffset());
+        }
+    }
+
+    @Test
+    public void shouldReportCorrectPositionAfterRelativeSeekWhenInputIsAtAnOffset() throws IOException {
+        input.read();
+        try (
+            SeekableInputStream seekable = SeekableInputStream.getSeekableStream(input);
+        ) {
+            assertEquals(0, seekable.getOffset());
+
+            seekable.seekFromCurrentPosition(5);
+            assertEquals(5, seekable.getOffset());
+        }
+    }
+
+    @Test
+    public void shouldReportCorrectPositionAfterSeekFromEnd() throws IOException {
+        try (
+            SeekableInputStream seekable = SeekableInputStream.getSeekableStream(input);
+        ) {
+            assertEquals(0, seekable.getOffset());
+            seekable.seekFromEnd(1);
+            assertEquals(size - 1, seekable.getOffset());
+        }
+    }
+
+    @Test
+    public void shouldReportCorrectPositionAfterSeekFromEndWhenInputIsAtAnOffset() throws IOException {
+        input.read();
+        try (
+            SeekableInputStream seekable = SeekableInputStream.getSeekableStream(input);
+        ) {
+            assertEquals(0, seekable.getOffset());
+            seekable.seekFromEnd(1);
+            assertEquals(size - 2, seekable.getOffset());
+        }
+    }
+
+    @Test
+    public void closingASeekableStreamShouldNotInterfereWithTheOriginal() throws IOException {
+        assertEquals(0, input.read());
+        input.mark(Integer.MAX_VALUE);
+        assertEquals(1, input.read());
+        try (
+            SeekableInputStream seekable = SeekableInputStream.getSeekableStream(input);
+        ) {
+            assertEquals(2, seekable.read());
+        }
+        input.reset();
+        assertEquals(1, input.read());
+    }
+
+    @Test(expected = IOException.class)
+    public void shouldNotBeAbleToUnreadAtStart() throws IOException {
+        try (
+            SeekableInputStream seekable = SeekableInputStream.getSeekableStream(input);
+        ) {
+            seekable.unread();
+        }
+    }
+
+    @Test
+    public void peekShouldReturnCorrectData() throws IOException {
+        try (
+            SeekableInputStream seekable = SeekableInputStream.getSeekableStream(input);
+        ) {
+            for (int i = 0; i < size; i++) {
+                int peeked = seekable.peek();
+                int read = seekable.read();
+                assertEquals(read, peeked);
+                assertEquals(i + 1, seekable.getOffset());
+            }
+        }
+    }
+}


### PR DESCRIPTION
This reduces the number of temp files, by special-casing creation of a seekable stream from an existing seekable stream (as opposed to a generic InputStream) to re-use the buffer or file of the existing.
While working on this, I found a few minor issues with the existing code (e.g. inconsistent behaviour between ASMemoryInStream and InternalInputStream). These are fixed in separate commits, along with test cases.
In order to show that the re-use of buffers/files is safe, I´ve added a largeish testcase, which runs a set of tests against seekable streams created in a number of different ways, to show that the manner the stream was created does not affect the behaviour. These tests are added as a separate commit before the commit that enables the re-use, so that it´s easy to verify that the re-use (which is just an optimiazation) does not affect the behaviour.
One way of verifying that the number of temp files created is reduced is to run the existing testcase `org.verapdf.pd.font.opentype.OpenTypeCFFTest` with and without this change, while monitoring the temp directory with `inotify` or `fswatch` or similar. Without the change, two `tmp_pdf_file` files are created. With the change applied, no such files are created.