### PR TITLE
Handle edge case in getSeekableStream method with maxStreamSize

### DIFF
--- a/src/main/java/org/verapdf/io/InternalInputStream.java
+++ b/src/main/java/org/verapdf/io/InternalInputStream.java
@@ -280,6 +280,9 @@ public class InternalInputStream extends SeekableInputStream {
 	}
 
 	private static File createTempFile(byte[] alreadyRead, InputStream input, Integer maxStreamSize) throws IOException {
+		if (maxStreamSize != null && alreadyRead.length > maxStreamSize) {
+			throw new VeraPDFParserException("Maximum allowed stream size exceeded");
+		}
 		File tmpFile = File.createTempFile("tmp_pdf_file", ".pdf");
 		try (FileOutputStream output = new FileOutputStream(tmpFile)) {
 			output.write(alreadyRead);

--- a/src/test/java/org/verapdf/io/SeekableInputStreamParametricTest.java
+++ b/src/test/java/org/verapdf/io/SeekableInputStreamParametricTest.java
@@ -26,6 +26,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.verapdf.as.io.ASInputStream;
 import org.verapdf.as.io.ASMemoryInStream;
+import org.verapdf.exceptions.VeraPDFParserException;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -38,6 +39,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 /**
  * Tests behaviour of SeekableInputStreams, build from different kinds of source streams.
@@ -423,5 +425,19 @@ public class SeekableInputStreamParametricTest {
                 assertEquals(i + 1, seekable.getOffset());
             }
         }
+    }
+
+    @Test
+    public void shouldNotThrowExceptionsAboutExceedingMaxSizeWhenNotExeedingMaxSize() throws IOException {
+        try (
+            SeekableInputStream seekable = SeekableInputStream.getSeekableStream(input, size);
+        ) {
+            assertEquals(seekable.getOffset(), 0);
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionsAboutExceedingMaxSizeWhenExeedingMaxSize() {
+        assertThrows(VeraPDFParserException.class, () -> SeekableInputStream.getSeekableStream(input, size - 1));
     }
 }


### PR DESCRIPTION
Handles the edge case in `InternalInputStream.getSeekableStream` where `alreadyRead` is larger than the `maxStreamSize`, but the `stream` is already at EOF. In that case, the loop never runs, so the check whether `totalRead > maxStreamSize` was not executed, leading to the exception not being thrown. This should never happen when called via `SeekableInputStream.getSeekableStream`, but `InternalInputStream.createConcatenated` is public, and could be called incorrectly.