### PR TITLE
Fix getXRefInfo method of PDFParser

### DIFF
--- a/src/main/java/org/verapdf/parser/PDFParser.java
+++ b/src/main/java/org/verapdf/parser/PDFParser.java
@@ -571,8 +571,12 @@ public class PDFParser extends SeekableCOSParser {
             }
         }
 
-        boolean shouldStopIteration = false;
-        while (!shouldStopIteration) {
+        List<Long> prevOffsets = new ArrayList<>();
+        while (offset != null || !prevOffsets.isEmpty()) {
+            if (offset == null) {
+                offset = prevOffsets.removeLast();
+            }
+
             if (processedOffsets.contains(offset)) {
                 throw new LoopedException(getErrorMessage("XRef loop"));
             }
@@ -599,15 +603,12 @@ public class PDFParser extends SeekableCOSParser {
             getXRefSectionAndTrailer(section);
             COSTrailer trailer = section.getTrailer();
 
-            offset = trailer.getXRefStm();
-            if (offset != null) {
-                continue;
+            Long prevOffset = trailer.getPrev();
+            if (prevOffset != null) {
+                prevOffsets.add(prevOffset);
             }
 
-            offset = trailer.getPrev();
-            if (offset == null) {
-                shouldStopIteration = true;
-            }
+            offset = trailer.getXRefStm();
         }
 	}
 

--- a/src/main/java/org/verapdf/parser/PDFParser.java
+++ b/src/main/java/org/verapdf/parser/PDFParser.java
@@ -574,7 +574,7 @@ public class PDFParser extends SeekableCOSParser {
         List<Long> prevOffsets = new ArrayList<>();
         while (offset != null || !prevOffsets.isEmpty()) {
             if (offset == null) {
-                offset = prevOffsets.removeLast();
+                offset = prevOffsets.remove(prevOffsets.size() - 1);
             }
 
             if (processedOffsets.contains(offset)) {

--- a/src/main/java/org/verapdf/parser/PDFParser.java
+++ b/src/main/java/org/verapdf/parser/PDFParser.java
@@ -575,10 +575,9 @@ public class PDFParser extends SeekableCOSParser {
         while (offset != null || !prevOffsets.isEmpty()) {
             if (offset == null) {
                 offset = prevOffsets.remove(prevOffsets.size() - 1);
-            }
-
-            if (processedOffsets.contains(offset)) {
-                throw new LoopedException(getErrorMessage("XRef loop"));
+                if (processedOffsets.contains(offset)) {
+                    throw new LoopedException(getErrorMessage("XRef loop"));
+                }
             }
             processedOffsets.add(offset);
 

--- a/src/main/java/org/verapdf/parser/PDFParser.java
+++ b/src/main/java/org/verapdf/parser/PDFParser.java
@@ -571,10 +571,10 @@ public class PDFParser extends SeekableCOSParser {
             }
         }
 
-        List<Long> prevOffsets = new ArrayList<>();
-        while (offset != null || !prevOffsets.isEmpty()) {
+        Stack<Long> prevOffsets = new Stack<>();
+        while (offset != null || !prevOffsets.empty()) {
             if (offset == null) {
-                offset = prevOffsets.remove(prevOffsets.size() - 1);
+                offset = prevOffsets.pop();
                 if (processedOffsets.contains(offset)) {
                     throw new LoopedException(getErrorMessage("XRef loop"));
                 }
@@ -607,7 +607,7 @@ public class PDFParser extends SeekableCOSParser {
 
             Long prevOffset = trailer.getPrev();
             if (prevOffset != null) {
-                prevOffsets.add(prevOffset);
+                prevOffsets.push(prevOffset);
             }
 
             offset = trailer.getXRefStm();

--- a/src/main/java/org/verapdf/parser/PDFParser.java
+++ b/src/main/java/org/verapdf/parser/PDFParser.java
@@ -571,7 +571,8 @@ public class PDFParser extends SeekableCOSParser {
             }
         }
 
-        while (offset != null) {
+        boolean shouldStopIteration = false;
+        while (!shouldStopIteration) {
             if (processedOffsets.contains(offset)) {
                 throw new LoopedException(getErrorMessage("XRef loop"));
             }
@@ -604,6 +605,9 @@ public class PDFParser extends SeekableCOSParser {
             }
 
             offset = trailer.getPrev();
+            if (offset == null) {
+                shouldStopIteration = true;
+            }
         }
 	}
 

--- a/src/main/java/org/verapdf/parser/PDFParser.java
+++ b/src/main/java/org/verapdf/parser/PDFParser.java
@@ -578,6 +578,9 @@ public class PDFParser extends SeekableCOSParser {
                 if (processedOffsets.contains(offset)) {
                     throw new LoopedException(getErrorMessage("XRef loop"));
                 }
+            } else if (processedOffsets.contains(offset)) {
+                offset = null;
+                continue;
             }
             processedOffsets.add(offset);
 


### PR DESCRIPTION
The change from recursive to iterative executioin is required to prevent StackOverflow exceptions when processing documents having many xref objects.
The second change prevents xref loop exception being caused by repeating XRefStm offset in multiple trailers from happening