### PR TITLE
Fix NullPointerExceprion when getGID() was called on null

### DIFF
--- a/src/main/java/org/verapdf/pd/font/truetype/TrueTypeFontProgram.java
+++ b/src/main/java/org/verapdf/pd/font/truetype/TrueTypeFontProgram.java
@@ -224,6 +224,9 @@ public class TrueTypeFontProgram extends BaseTrueTypeProgram implements FontProg
             gid = cmap10.getGlyph(code);
             return getWidthWithCheck(gid);
         }
+        if (this.parser.getCmapParser() == null) {
+            return 0;
+        }
         gid = this.parser.getCmapParser().getGID(code);
         return getWidthWithCheck(gid);
     }

--- a/src/main/java/org/verapdf/pd/font/truetype/TrueTypeFontProgram.java
+++ b/src/main/java/org/verapdf/pd/font/truetype/TrueTypeFontProgram.java
@@ -126,6 +126,9 @@ public class TrueTypeFontProgram extends BaseTrueTypeProgram implements FontProg
                 width = getWidth(TrueTypePredefined.NOTDEF_STRING);
             }
             if (width == -1) {
+                if (this.parser.getCmapParser() == null) {
+                    return 0;
+                }
                 int gid = this.parser.getCmapParser().getGID(code);
                 return getWidthWithCheck(gid);
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when processing TrueType fonts with missing or incomplete character mapping data; the renderer now safely falls back to a zero width for unmapped glyphs, avoiding errors for both standard and symbolic mappings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->