### PR TITLE
Fix memory allocation in PSOperator and Type1FontProgram

### DIFF
--- a/src/main/java/org/verapdf/parser/postscript/PSOperator.java
+++ b/src/main/java/org/verapdf/parser/postscript/PSOperator.java
@@ -28,6 +28,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Represents executable PostScript operator.
@@ -35,6 +37,8 @@ import java.util.Stack;
  * @author Sergey Shemyakov
  */
 public class PSOperator extends PSObject {
+
+    private static final Logger LOGGER = Logger.getLogger(PSOperator.class.getCanonicalName());
     private static final int MAX_PS_ARRAY_SIZE = 1 << 16;
     private static final int MAX_PS_FOR_ITERATIONS = 10_000;
     private Stack<COSObject> operandStack;
@@ -537,11 +541,11 @@ public class PSOperator extends PSObject {
 
     private void array() throws PostScriptException {
         try {
-            int arraySize = getTopNumber().getInteger().intValue();
+            Long arraySize = getTopNumber().getInteger();
             if (arraySize < 0 || arraySize > MAX_PS_ARRAY_SIZE) {
                 throw new PostScriptException("Array size " + arraySize + " is out of range");
             }
-            COSObject array = COSArray.construct(arraySize);
+            COSObject array = COSArray.construct(arraySize.intValue());
             for (int i = 0; i < arraySize; i++) {
                 array.add(COSObject.getEmpty());
             }
@@ -586,15 +590,18 @@ public class PSOperator extends PSObject {
             long increment = getTopNumber().getInteger();
             long initial = getTopNumber().getInteger();
             if (increment == 0 || (increment > 0 && initial > limit) || (increment < 0 && initial < limit)) {
-                throw new PostScriptException("Wrong increment value " + increment);
+                LOGGER.log(Level.WARNING, "Wrong increment value " + increment + " for operator 'for'");
+                increment = 0;
             }
-            long iterations = Math.abs((limit - initial) / increment) + 1;
-            if (iterations > MAX_PS_FOR_ITERATIONS) {
-                throw new PostScriptException("Loop iteration count " + iterations + " is too large");
-            }
-            for (long i = initial; (increment > 0 ? i <= limit : i >= limit); i += increment) {
-                operandStack.push(COSInteger.construct(i));
-                ((PSProcedure) proc).executeProcedure(operandStack, userDict);
+            if (increment != 0) {
+                long iterations = Math.abs((limit - initial) / increment) + 1;
+                if (iterations > MAX_PS_FOR_ITERATIONS) {
+                    throw new PostScriptException("Loop iteration count " + iterations + " is too large");
+                }
+                for (long i = initial; (increment > 0 ? i <= limit : i >= limit); i += increment) {
+                    operandStack.push(COSInteger.construct(i));
+                    ((PSProcedure) proc).executeProcedure(operandStack, userDict);
+                }
             }
 
         } catch (PostScriptException e) {

--- a/src/main/java/org/verapdf/pd/font/type1/Type1FontProgram.java
+++ b/src/main/java/org/verapdf/pd/font/type1/Type1FontProgram.java
@@ -192,7 +192,7 @@ public class Type1FontProgram extends PSParser implements FontProgram {
     }
 
     private void toExecute(COSObject next, int depth) throws PostScriptException {
-        if (depth > MAX_TO_EXECUTE_DEPTH) {
+        if (depth >= MAX_TO_EXECUTE_DEPTH) {
             throw new PostScriptException("Type 1 font program exceeded toExecute recursion depth");
         }
         PSObject operator = PSObject.getPSObject(next);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened PostScript operand validation: array size and loop iteration limits now prevent excessively large or malformed values, causing invalid loops to be skipped and avoiding processing errors or hangs when encountering problematic PDFs.
  * Added limits to nested PostScript execution in font programs to prevent excessive recursion, reducing risk of resource exhaustion and improving stability when parsing complex PDF content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/veraPDF/veraPDF-parser/pull/703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->