### PR TITLE
Remove punctuation symbols inside font family

### DIFF
--- a/src/main/java/org/verapdf/pd/font/PDFontDescriptor.java
+++ b/src/main/java/org/verapdf/pd/font/PDFontDescriptor.java
@@ -126,6 +126,7 @@ public class PDFontDescriptor extends PDObject {
         if (fontNameWithoutSubset == null || fontNameWithoutSubset.isEmpty()) return null;
 
         String name = fontNameWithoutSubset.trim();
+        name = name.replaceAll("[^a-zA-Z0-9\\s-]+", "");
         name = name.replaceAll("\\*\\d+", "");
 
         boolean changed = true;

--- a/src/main/java/org/verapdf/pd/font/PDFontDescriptor.java
+++ b/src/main/java/org/verapdf/pd/font/PDFontDescriptor.java
@@ -126,8 +126,8 @@ public class PDFontDescriptor extends PDObject {
         if (fontNameWithoutSubset == null || fontNameWithoutSubset.isEmpty()) return null;
 
         String name = fontNameWithoutSubset.trim();
-        name = name.replaceAll("[^a-zA-Z0-9\\s-]+", "");
         name = name.replaceAll("\\*\\d+", "");
+        name = name.replaceAll("[^a-zA-Z0-9\\s-]+", "");
 
         boolean changed = true;
         while (changed) {

--- a/src/main/java/org/verapdf/pd/font/PDFontDescriptor.java
+++ b/src/main/java/org/verapdf/pd/font/PDFontDescriptor.java
@@ -127,7 +127,7 @@ public class PDFontDescriptor extends PDObject {
 
         String name = fontNameWithoutSubset.trim();
         name = name.replaceAll("\\*\\d+", "");
-        name = name.replaceAll("[^a-zA-Z0-9\\s-]+", "");
+        name = name.replaceAll("[,.;:!?]+", "");
 
         boolean changed = true;
         while (changed) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced font family name extraction to remove common punctuation characters (comma, period, semicolon, colon, exclamation mark, question mark) from font identifiers. This improvement ensures more accurate font matching and consistent text rendering across different font specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->