### PR TITLE
Add getL and getStreamLength methods to PDInlineImage

### DIFF
--- a/src/main/java/org/verapdf/parser/PDFStreamParser.java
+++ b/src/main/java/org/verapdf/parser/PDFStreamParser.java
@@ -281,6 +281,10 @@ public class PDFStreamParser extends NotSeekableCOSParser {
 		if (!imageEndFound) {
 			LOGGER.log(Level.WARNING, "End of inline image not found");
 		}
+        int lastIndex = image.size() - 1;
+        if (CharTable.isSpace(image.get(lastIndex))) {
+            image.remove(lastIndex);
+        }
 		byte[] buffer = getByteArrayFromArrayList(image);
 		return new ASMemoryInStream(buffer, buffer.length, false);
 	}

--- a/src/main/java/org/verapdf/parser/PDFStreamParser.java
+++ b/src/main/java/org/verapdf/parser/PDFStreamParser.java
@@ -281,9 +281,11 @@ public class PDFStreamParser extends NotSeekableCOSParser {
 		if (!imageEndFound) {
 			LOGGER.log(Level.WARNING, "End of inline image not found");
 		}
-        int lastIndex = image.size() - 1;
-        if (CharTable.isSpace(image.get(lastIndex))) {
-            image.remove(lastIndex);
+        if (!image.isEmpty()) {
+            int lastIndex = image.size() - 1;
+            if (CharTable.isSpace(image.get(lastIndex))) {
+                image.remove(lastIndex);
+            }
         }
 		byte[] buffer = getByteArrayFromArrayList(image);
 		return new ASMemoryInStream(buffer, buffer.length, false);

--- a/src/main/java/org/verapdf/pd/images/PDInlineImage.java
+++ b/src/main/java/org/verapdf/pd/images/PDInlineImage.java
@@ -43,13 +43,15 @@ public class PDInlineImage extends PDResource {
 
 	private final PDResources imageResources;
 	private final PDResources pageResources;
+    private final long dataStreamLength;
 
 	public PDInlineImage(COSObject obj, PDResources imageResources,
-						 PDResources pageResources) {
+                         PDResources pageResources, long dataStreamLength) {
 		super(obj);
 		this.imageResources = imageResources;
 		this.pageResources = pageResources;
-	}
+        this.dataStreamLength = dataStreamLength;
+    }
 
 	public boolean isInterpolate() {
 		COSObject interpolate = getInlineImageKey(getObject().get(), ASAtom.INTERPOLATE);
@@ -61,6 +63,14 @@ public class PDInlineImage extends PDResource {
 		COSObject bitsPerComponent = getInlineImageKey(getObject().get(), ASAtom.BITS_PER_COMPONENT);
 		return bitsPerComponent.getInteger();
 	}
+
+    public Long getL() {
+        return getInlineImageKey(getObject().get(), ASAtom.LENGTH).getInteger();
+    }
+
+    public Long getStreamLength() {
+        return this.dataStreamLength;
+    }
 
 	public List<COSName> getCOSFilters() {
 		COSObject filters = getInlineImageKey(getObject().get(), ASAtom.FILTER);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inline image parsing by removing unintended trailing whitespace from image data.
  - Preserved accurate inline image stream length information for downstream processing.

- **Enhancements**
  - Added access to inline image length metadata and stream size for improved image data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->