### PR TITLE
Use Long instead of primitive for dataStreamLength

### DIFF
--- a/src/main/java/org/verapdf/pd/images/PDInlineImage.java
+++ b/src/main/java/org/verapdf/pd/images/PDInlineImage.java
@@ -43,10 +43,10 @@ public class PDInlineImage extends PDResource {
 
 	private final PDResources imageResources;
 	private final PDResources pageResources;
-    private final long dataStreamLength;
+    private final Long dataStreamLength;
 
 	public PDInlineImage(COSObject obj, PDResources imageResources,
-                         PDResources pageResources, long dataStreamLength) {
+                         PDResources pageResources, Long dataStreamLength) {
 		super(obj);
 		this.imageResources = imageResources;
 		this.pageResources = pageResources;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of inline image stream lengths when the value is unavailable.
  * Inline image metadata can now accurately represent missing length information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->