### PR TITLE
Add isEquivalentTo method to COSBase and COSObject

### DIFF
--- a/src/main/java/org/verapdf/cos/COSArray.java
+++ b/src/main/java/org/verapdf/cos/COSArray.java
@@ -190,26 +190,24 @@ public class COSArray extends COSDirect implements Iterable<COSObject> {
     }
 
     @Override
-    public boolean isEquivalentTo(Object o) {
+    public boolean isEquivalentTo(COSBase o) {
         if (this == o) return true;
         if (o == null) return false;
 
-        if (o instanceof COSObject) {
-            return this.isEquivalentTo(((COSObject) o).get());
+        if (o.isIndirect()) {
+            return this.isEquivalentTo(o.getDirectBase());
         }
+
         if (!(o instanceof COSArray)) return false;
         List<COSBasePair> checkedObjects = new LinkedList<>();
         return isEquivalentTo(o, checkedObjects);
     }
 
     @Override
-    boolean isEquivalentTo(Object o, List<COSBasePair> checkedObjects) {
+    boolean isEquivalentTo(COSBase o, List<COSBasePair> checkedObjects) {
         if (this == o) return true;
         if (o == null) return false;
 
-        if (o instanceof COSObject) {
-            return this.isEquivalentTo(((COSObject) o).get(), checkedObjects);
-        }
         if (!(o instanceof COSArray)) return false;
 
         COSArray that = (COSArray) o;
@@ -218,7 +216,7 @@ public class COSArray extends COSDirect implements Iterable<COSObject> {
         }
         COSBasePair.addPairToList(checkedObjects, this, that);
 
-        if (this.size() != that.size()) return false;
+        if (!Objects.equals(this.size(), that.size())) return false;
 
         for (int i = 0; i < this.size(); ++i) {
             COSBase thisElem = this.at(i).getDirectBase();

--- a/src/main/java/org/verapdf/cos/COSArray.java
+++ b/src/main/java/org/verapdf/cos/COSArray.java
@@ -190,6 +190,51 @@ public class COSArray extends COSDirect implements Iterable<COSObject> {
     }
 
     @Override
+    public boolean isEquivalentTo(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+
+        if (o instanceof COSObject) {
+            return this.isEquivalentTo(((COSObject) o).get());
+        }
+        if (!(o instanceof COSArray)) return false;
+        List<COSBasePair> checkedObjects = new LinkedList<>();
+        return isEquivalentTo(o, checkedObjects);
+    }
+
+    @Override
+    boolean isEquivalentTo(Object o, List<COSBasePair> checkedObjects) {
+        if (this == o) return true;
+        if (o == null) return false;
+
+        if (o instanceof COSObject) {
+            return this.isEquivalentTo(((COSObject) o).get(), checkedObjects);
+        }
+        if (!(o instanceof COSArray)) return false;
+
+        COSArray that = (COSArray) o;
+        if (COSBasePair.listContainsPair(checkedObjects, this, that)) {
+            return true;
+        }
+        COSBasePair.addPairToList(checkedObjects, this, that);
+
+        if (this.size() != that.size()) return false;
+
+        for (int i = 0; i < this.size(); ++i) {
+            COSBase thisElem = this.at(i).getDirectBase();
+            COSBase thatElem = that.at(i).getDirectBase();
+
+            if (thisElem == null && thatElem == null) continue;
+            if (thisElem == null || thatElem == null) return false;
+
+            if (!thisElem.isEquivalentTo(thatElem, checkedObjects)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;

--- a/src/main/java/org/verapdf/cos/COSBase.java
+++ b/src/main/java/org/verapdf/cos/COSBase.java
@@ -140,9 +140,9 @@ public abstract class COSBase {
 
 	public abstract void mark();
 
-    public abstract boolean isEquivalentTo(Object obj);
+    public abstract boolean isEquivalentTo(COSBase obj);
 
-    boolean isEquivalentTo(Object o, List<COSBasePair> checkedObjects) {
+    boolean isEquivalentTo(COSBase o, List<COSBasePair> checkedObjects) {
         return isEquivalentTo(o);
     }
 

--- a/src/main/java/org/verapdf/cos/COSBase.java
+++ b/src/main/java/org/verapdf/cos/COSBase.java
@@ -140,6 +140,12 @@ public abstract class COSBase {
 
 	public abstract void mark();
 
+    public abstract boolean isEquivalentTo(Object obj);
+
+    boolean isEquivalentTo(Object o, List<COSBasePair> checkedObjects) {
+        return isEquivalentTo(o);
+    }
+
 	boolean equals(Object obj, List<COSBasePair> checkedObjects) {
 		return this.equals(obj);
 	}

--- a/src/main/java/org/verapdf/cos/COSBoolean.java
+++ b/src/main/java/org/verapdf/cos/COSBoolean.java
@@ -71,6 +71,17 @@ public class COSBoolean extends COSDirect {
         return true;
     }
 
+    @Override
+    public boolean isEquivalentTo(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof COSBoolean)) return false;
+
+        COSBoolean that = (COSBoolean) o;
+
+        return value == that.value;
+
+    }
+
     public boolean get() {
         return this.value;
     }

--- a/src/main/java/org/verapdf/cos/COSBoolean.java
+++ b/src/main/java/org/verapdf/cos/COSBoolean.java
@@ -72,8 +72,13 @@ public class COSBoolean extends COSDirect {
     }
 
     @Override
-    public boolean isEquivalentTo(Object o) {
+    public boolean isEquivalentTo(COSBase o) {
         if (this == o) return true;
+
+        if (o.isIndirect()) {
+            return isEquivalentTo(o.getDirectBase());
+        }
+
         if (!(o instanceof COSBoolean)) return false;
 
         COSBoolean that = (COSBoolean) o;

--- a/src/main/java/org/verapdf/cos/COSBoolean.java
+++ b/src/main/java/org/verapdf/cos/COSBoolean.java
@@ -74,6 +74,7 @@ public class COSBoolean extends COSDirect {
     @Override
     public boolean isEquivalentTo(COSBase o) {
         if (this == o) return true;
+        if (o == null) return false;
 
         if (o.isIndirect()) {
             return isEquivalentTo(o.getDirectBase());

--- a/src/main/java/org/verapdf/cos/COSDictionary.java
+++ b/src/main/java/org/verapdf/cos/COSDictionary.java
@@ -302,7 +302,7 @@ public class COSDictionary extends COSDirect {
     private Set<ASAtom> getNonNullKeySet() {
         Set<ASAtom> nonNullKeys = new HashSet<>();
         for (ASAtom key : getKeySet()) {
-            COSBase value = getKey(key).get(); // assume getKey returns a COSBase wrapper
+            COSBase value = getKey(key).getDirectBase();
             if (value != null) {
                 nonNullKeys.add(key);
             }
@@ -311,12 +311,14 @@ public class COSDictionary extends COSDirect {
     }
 
     @Override
-    public boolean isEquivalentTo(Object o) {
+    public boolean isEquivalentTo(COSBase o) {
         if (this == o) return true;
         if (o == null) return false;
-        if (o instanceof COSObject) {
-            return this.isEquivalentTo(((COSObject) o).get());
+
+        if (o.isIndirect()) {
+            return isEquivalentTo(o.getDirectBase());
         }
+
         if (!(o instanceof COSDictionary)) return false;
 
         List<COSBasePair> checkedObjects = new LinkedList<>();
@@ -326,12 +328,9 @@ public class COSDictionary extends COSDirect {
     /**
      * Internal recursive comparison with cycle detection.
      */
-    boolean isEquivalentTo(Object o, List<COSBasePair> checkedObjects) {
+    boolean isEquivalentTo(COSBase o, List<COSBasePair> checkedObjects) {
         if (this == o) return true;
         if (o == null) return false;
-        if (o instanceof COSObject) {
-            return this.isEquivalentTo(((COSObject) o).get(), checkedObjects);
-        }
         if (!(o instanceof COSDictionary)) return false;
 
         COSDictionary that = (COSDictionary) o;
@@ -348,9 +347,13 @@ public class COSDictionary extends COSDirect {
             return false;
         }
 
+        return isEquivalentKeys(that, thisKeys, checkedObjects);
+    }
+
+    protected boolean isEquivalentKeys(COSDictionary that, Set<ASAtom> thisKeys, List<COSBasePair> checkedObjects) {
         for (ASAtom key : thisKeys) {
-            COSBase thisVal = this.getKey(key).get();
-            COSBase thatVal = that.getKey(key).get();
+            COSBase thisVal = this.getKey(key).getDirectBase();
+            COSBase thatVal = that.getKey(key).getDirectBase();
 
             if (thisVal == null && thatVal == null) continue;
             if (thisVal == null || thatVal == null) return false;

--- a/src/main/java/org/verapdf/cos/COSDictionary.java
+++ b/src/main/java/org/verapdf/cos/COSDictionary.java
@@ -299,6 +299,70 @@ public class COSDictionary extends COSDirect {
         return this.entries.values();
     }
 
+    private Set<ASAtom> getNonNullKeySet() {
+        Set<ASAtom> nonNullKeys = new HashSet<>();
+        for (ASAtom key : getKeySet()) {
+            COSBase value = getKey(key).get(); // assume getKey returns a COSBase wrapper
+            if (value != null) {
+                nonNullKeys.add(key);
+            }
+        }
+        return nonNullKeys;
+    }
+
+    @Override
+    public boolean isEquivalentTo(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        if (o instanceof COSObject) {
+            return this.isEquivalentTo(((COSObject) o).get());
+        }
+        if (!(o instanceof COSDictionary)) return false;
+
+        List<COSBasePair> checkedObjects = new LinkedList<>();
+        return isEquivalentTo(o, checkedObjects);
+    }
+
+    /**
+     * Internal recursive comparison with cycle detection.
+     */
+    boolean isEquivalentTo(Object o, List<COSBasePair> checkedObjects) {
+        if (this == o) return true;
+        if (o == null) return false;
+        if (o instanceof COSObject) {
+            return this.isEquivalentTo(((COSObject) o).get(), checkedObjects);
+        }
+        if (!(o instanceof COSDictionary)) return false;
+
+        COSDictionary that = (COSDictionary) o;
+
+        if (COSBasePair.listContainsPair(checkedObjects, this, that)) {
+            return true;
+        }
+        COSBasePair.addPairToList(checkedObjects, this, that);
+
+        Set<ASAtom> thisKeys = this.getNonNullKeySet();
+        Set<ASAtom> thatKeys = that.getNonNullKeySet();
+
+        if (!thisKeys.equals(thatKeys)) {
+            return false;
+        }
+
+        for (ASAtom key : thisKeys) {
+            COSBase thisVal = this.getKey(key).get();
+            COSBase thatVal = that.getKey(key).get();
+
+            if (thisVal == null && thatVal == null) continue;
+            if (thisVal == null || thatVal == null) return false;
+
+            if (!thisVal.isEquivalentTo(thatVal, checkedObjects)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {

--- a/src/main/java/org/verapdf/cos/COSIndirect.java
+++ b/src/main/java/org/verapdf/cos/COSIndirect.java
@@ -481,6 +481,22 @@ public class COSIndirect extends COSBase {
     }
 
     @Override
+    public boolean isEquivalentTo(Object o) {
+        if (this == o) return true;
+
+        if (o instanceof COSIndirect) {
+            COSIndirect that = (COSIndirect) o;
+            return this.getDirect().isEquivalentTo(that.getDirect());
+        }
+
+        if (o instanceof COSObject) {
+            return this.getDirect().isEquivalentTo(o);
+        }
+
+        return false;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof COSIndirect)) return false;

--- a/src/main/java/org/verapdf/cos/COSIndirect.java
+++ b/src/main/java/org/verapdf/cos/COSIndirect.java
@@ -481,19 +481,14 @@ public class COSIndirect extends COSBase {
     }
 
     @Override
-    public boolean isEquivalentTo(Object o) {
+    public boolean isEquivalentTo(COSBase o) {
         if (this == o) return true;
 
-        if (o instanceof COSIndirect) {
-            COSIndirect that = (COSIndirect) o;
-            return this.getDirect().isEquivalentTo(that.getDirect());
-        }
+        COSBase thisBase = this.getDirectBase();
+        if (thisBase == null && o == null) return true;
+        if (thisBase == null || o == null) return false;
 
-        if (o instanceof COSObject) {
-            return this.getDirect().isEquivalentTo(o);
-        }
-
-        return false;
+        return thisBase.isEquivalentTo(o.getDirectBase());
     }
 
     @Override

--- a/src/main/java/org/verapdf/cos/COSInteger.java
+++ b/src/main/java/org/verapdf/cos/COSInteger.java
@@ -78,8 +78,12 @@ public class COSInteger extends COSNumber {
     }
 
     @Override
-    public boolean isEquivalentTo(Object o) {
+    public boolean isEquivalentTo(COSBase o) {
         if (this == o) return true;
+
+        if (o.isIndirect()) {
+            return isEquivalentTo(o.getDirectBase());
+        }
 
         if (o instanceof COSInteger) {
             return this.value == ((COSInteger) o).value;

--- a/src/main/java/org/verapdf/cos/COSInteger.java
+++ b/src/main/java/org/verapdf/cos/COSInteger.java
@@ -80,6 +80,7 @@ public class COSInteger extends COSNumber {
     @Override
     public boolean isEquivalentTo(COSBase o) {
         if (this == o) return true;
+        if (o == null) return false;
 
         if (o.isIndirect()) {
             return isEquivalentTo(o.getDirectBase());

--- a/src/main/java/org/verapdf/cos/COSInteger.java
+++ b/src/main/java/org/verapdf/cos/COSInteger.java
@@ -23,6 +23,8 @@ package org.verapdf.cos;
 import org.verapdf.cos.visitor.ICOSVisitor;
 import org.verapdf.cos.visitor.IVisitor;
 
+import java.math.BigDecimal;
+
 /**
  * @author Timur Kamalov
  */
@@ -75,6 +77,22 @@ public class COSInteger extends COSNumber {
         return true;
     }
 
+    @Override
+    public boolean isEquivalentTo(Object o) {
+        if (this == o) return true;
+
+        if (o instanceof COSInteger) {
+            return this.value == ((COSInteger) o).value;
+        }
+
+        if (o instanceof COSReal) {
+            COSReal thatReal = (COSReal) o;
+            return BigDecimal.valueOf(this.value).compareTo(thatReal.getDecimalValue()) == 0;
+        }
+
+        return false;
+    }
+
     public long get() {
         return this.value;
     }
@@ -96,5 +114,10 @@ public class COSInteger extends COSNumber {
 
         return value == that.value;
 
+    }
+
+    @Override
+    public BigDecimal getDecimalValue() {
+        return BigDecimal.valueOf(value);
     }
 }

--- a/src/main/java/org/verapdf/cos/COSName.java
+++ b/src/main/java/org/verapdf/cos/COSName.java
@@ -93,16 +93,18 @@ public class COSName extends COSDirect {
     }
 
     @Override
-    public boolean isEquivalentTo(Object o) {
+    public boolean isEquivalentTo(COSBase o) {
         if (this == o) return true;
+
+        if (o.isIndirect()) {
+            return isEquivalentTo(o.getDirectBase());
+        }
+
         if (!(o instanceof COSName)) return false;
 
         COSName that = (COSName) o;
 
-        byte[] thisBytes = this.getName().getValue().getBytes(StandardCharsets.ISO_8859_1);
-        byte[] thatBytes = that.getName().getValue().getBytes(StandardCharsets.ISO_8859_1);
-
-        return Arrays.equals(thisBytes, thatBytes);
+        return Objects.equals(value, that.value);
     }
 
     public ASAtom get() {

--- a/src/main/java/org/verapdf/cos/COSName.java
+++ b/src/main/java/org/verapdf/cos/COSName.java
@@ -95,6 +95,7 @@ public class COSName extends COSDirect {
     @Override
     public boolean isEquivalentTo(COSBase o) {
         if (this == o) return true;
+        if (o == null) return false;
 
         if (o.isIndirect()) {
             return isEquivalentTo(o.getDirectBase());

--- a/src/main/java/org/verapdf/cos/COSName.java
+++ b/src/main/java/org/verapdf/cos/COSName.java
@@ -25,6 +25,7 @@ import org.verapdf.cos.visitor.ICOSVisitor;
 import org.verapdf.cos.visitor.IVisitor;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -89,6 +90,19 @@ public class COSName extends COSDirect {
     public boolean setName(final ASAtom value) {
         set(value);
         return true;
+    }
+
+    @Override
+    public boolean isEquivalentTo(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof COSName)) return false;
+
+        COSName that = (COSName) o;
+
+        byte[] thisBytes = this.getName().getValue().getBytes(StandardCharsets.ISO_8859_1);
+        byte[] thatBytes = that.getName().getValue().getBytes(StandardCharsets.ISO_8859_1);
+
+        return Arrays.equals(thisBytes, thatBytes);
     }
 
     public ASAtom get() {

--- a/src/main/java/org/verapdf/cos/COSNull.java
+++ b/src/main/java/org/verapdf/cos/COSNull.java
@@ -52,6 +52,11 @@ public class COSNull extends COSDirect {
     }
 
     @Override
+    public boolean isEquivalentTo(Object o) {
+        return equals(o);
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         return o instanceof COSNull;

--- a/src/main/java/org/verapdf/cos/COSNull.java
+++ b/src/main/java/org/verapdf/cos/COSNull.java
@@ -52,7 +52,7 @@ public class COSNull extends COSDirect {
     }
 
     @Override
-    public boolean isEquivalentTo(Object o) {
+    public boolean isEquivalentTo(COSBase o) {
         return equals(o);
     }
 

--- a/src/main/java/org/verapdf/cos/COSNumber.java
+++ b/src/main/java/org/verapdf/cos/COSNumber.java
@@ -20,6 +20,8 @@
  */
 package org.verapdf.cos;
 
+import java.math.BigDecimal;
+
 /**
  * @author Timur Kamalov
  */
@@ -28,5 +30,7 @@ public abstract class COSNumber extends COSDirect {
     public COSNumber() {
         super();
     }
+
+    public abstract BigDecimal getDecimalValue();
 
 }

--- a/src/main/java/org/verapdf/cos/COSObject.java
+++ b/src/main/java/org/verapdf/cos/COSObject.java
@@ -494,6 +494,19 @@ public class COSObject {
 		this.isHeaderFormatComplyPDFA = isHeaderFormatComplyPDFA;
 	}
 
+    public boolean isEquivalentTo(Object o) {
+        if (o == this) return true;
+        if (o instanceof COSObject) {
+            COSObject cosObject = (COSObject) o;
+            return base.isEquivalentTo(cosObject.base);
+        }
+
+        if (o instanceof COSIndirect) {
+            return base.isEquivalentTo(((COSIndirect) o).getDirect().base);
+        }
+        return false;
+    }
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;

--- a/src/main/java/org/verapdf/cos/COSObject.java
+++ b/src/main/java/org/verapdf/cos/COSObject.java
@@ -494,17 +494,16 @@ public class COSObject {
 		this.isHeaderFormatComplyPDFA = isHeaderFormatComplyPDFA;
 	}
 
-    public boolean isEquivalentTo(Object o) {
+    public boolean isEquivalentTo(COSObject o) {
         if (o == this) return true;
-        if (o instanceof COSObject) {
-            COSObject cosObject = (COSObject) o;
-            return base.isEquivalentTo(cosObject.base);
-        }
+        if (o == null) return false;
 
-        if (o instanceof COSIndirect) {
-            return base.isEquivalentTo(((COSIndirect) o).getDirect().base);
-        }
-        return false;
+        COSBase thisBase = this.getDirectBase();
+        COSBase otherBase = o.getDirectBase();
+        if (thisBase == null && otherBase == null) return true;
+        if (thisBase == null || otherBase == null) return false;
+
+        return thisBase.isEquivalentTo(otherBase);
     }
 
 	@Override

--- a/src/main/java/org/verapdf/cos/COSReal.java
+++ b/src/main/java/org/verapdf/cos/COSReal.java
@@ -23,6 +23,7 @@ package org.verapdf.cos;
 import org.verapdf.cos.visitor.ICOSVisitor;
 import org.verapdf.cos.visitor.IVisitor;
 
+import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 
@@ -43,6 +44,11 @@ public class COSReal extends COSNumber {
     private double value;
 
     protected COSReal() {
+    }
+
+    @Override
+    public BigDecimal getDecimalValue() {
+        return BigDecimal.valueOf(value);
     }
 
     protected COSReal(final double value) {
@@ -86,6 +92,23 @@ public class COSReal extends COSNumber {
     public boolean setReal(final double value) {
         set(value);
         return true;
+    }
+
+    @Override
+    public boolean isEquivalentTo(Object o) {
+        if (this == o) return true;
+
+        if (o instanceof COSReal) {
+            COSReal thatReal = (COSReal) o;
+            return this.getDecimalValue().compareTo(thatReal.getDecimalValue()) == 0;
+        }
+
+        if (o instanceof COSInteger) {
+            COSInteger thatInt = (COSInteger) o;
+            return this.getDecimalValue().compareTo(thatInt.getDecimalValue()) == 0;
+        }
+
+        return false;
     }
 
     public double get() {

--- a/src/main/java/org/verapdf/cos/COSReal.java
+++ b/src/main/java/org/verapdf/cos/COSReal.java
@@ -95,8 +95,12 @@ public class COSReal extends COSNumber {
     }
 
     @Override
-    public boolean isEquivalentTo(Object o) {
+    public boolean isEquivalentTo(COSBase o) {
         if (this == o) return true;
+
+        if (o.isIndirect()) {
+            return isEquivalentTo(o.getDirectBase());
+        }
 
         if (o instanceof COSReal) {
             COSReal thatReal = (COSReal) o;

--- a/src/main/java/org/verapdf/cos/COSStream.java
+++ b/src/main/java/org/verapdf/cos/COSStream.java
@@ -283,6 +283,87 @@ public class COSStream extends COSDictionary {
 		DECRYPT_AND_DECODE
 	}
 
+    private Set<ASAtom> getNonNullKeysExcluding(Set<ASAtom> exclude) {
+        Set<ASAtom> keys = new HashSet<>(this.getKeySet());
+        keys.removeAll(exclude);
+        keys.removeIf(key -> this.getKey(key).get() == null);
+        return keys;
+    }
+
+    @Override
+    public boolean isEquivalentTo(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        if (o instanceof COSObject) {
+            return this.isEquivalentTo(((COSObject) o).get());
+        }
+        if (!(o instanceof COSStream)) return false;
+        List<COSBasePair> checkedObjects = new LinkedList<>();
+        return isEquivalentTo(o, checkedObjects);
+    }
+
+    @Override
+    boolean isEquivalentTo(Object o, List<COSBasePair> checkedObjects) {
+        if (this == o) return true;
+        if (o == null) return false;
+        if (o instanceof COSObject) {
+            return this.isEquivalentTo(((COSObject) o).get(), checkedObjects);
+        }
+        if (!(o instanceof COSStream)) return false;
+        COSStream that = (COSStream) o;
+
+        if (COSBasePair.listContainsPair(checkedObjects, this, that)) {
+            return true;
+        }
+        COSBasePair.addPairToList(checkedObjects, this, that);
+
+        try {
+            ASInputStream thisDecoded = this.getData(FilterFlags.DECODE);
+            ASInputStream thatDecoded = that.getData(FilterFlags.DECODE);
+            if (!equalsDecodedStreams(thisDecoded, thatDecoded)) {
+                return false;
+            }
+        } catch (IOException e) {
+            LOGGER.log(Level.FINE, "Exception during comparing decoded streams", e);
+            return false;
+        }
+
+        Set<ASAtom> excluded = new HashSet<>(Arrays.asList(ASAtom.LENGTH, ASAtom.FILTER, ASAtom.DECODE_PARMS));
+        Set<ASAtom> thisKeys = this.getNonNullKeysExcluding(excluded);
+        Set<ASAtom> thatKeys = that.getNonNullKeysExcluding(excluded);
+
+        if (!thisKeys.equals(thatKeys)) {
+            return false;
+        }
+        for (ASAtom key : thisKeys) {
+            COSBase thisVal = this.getKey(key).get();
+            COSBase thatVal = that.getKey(key).get();
+            if (thisVal == null && thatVal == null) continue;
+            if (thisVal == null || thatVal == null) return false;
+            if (!thisVal.isEquivalentTo(thatVal, checkedObjects)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static boolean equalsDecodedStreams(ASInputStream first, ASInputStream second) throws IOException {
+        byte[] buf1 = new byte[8192];
+        byte[] buf2 = new byte[8192];
+        int read1, read2;
+        while (true) {
+            read1 = first.read(buf1);
+            read2 = second.read(buf2);
+            if (read1 != read2) return false;
+            if (read1 == -1) break;
+            for (int i = 0; i < read1; i++) {
+                if (buf1[i] != buf2[i]) return false;
+            }
+        }
+        return true;
+    }
+
 	@Override
 	public boolean equals(Object obj) {
 		if (this == obj) {

--- a/src/main/java/org/verapdf/cos/COSStream.java
+++ b/src/main/java/org/verapdf/cos/COSStream.java
@@ -315,9 +315,12 @@ public class COSStream extends COSDictionary {
         }
         COSBasePair.addPairToList(checkedObjects, this, that);
 
-        try {
-            ASInputStream thisDecoded = this.getData(FilterFlags.DECODE);
-            ASInputStream thatDecoded = that.getData(FilterFlags.DECODE);
+        if (this.stream == null || that.stream == null) {
+            return this.stream == that.stream;
+        }
+
+        try (ASInputStream thisDecoded = this.getData(FilterFlags.DECODE);
+             ASInputStream thatDecoded = that.getData(FilterFlags.DECODE)) {
             if (!equalsDecodedStreams(thisDecoded, thatDecoded)) {
                 return false;
             }

--- a/src/main/java/org/verapdf/cos/COSStream.java
+++ b/src/main/java/org/verapdf/cos/COSStream.java
@@ -286,16 +286,16 @@ public class COSStream extends COSDictionary {
     private Set<ASAtom> getNonNullKeysExcluding(Set<ASAtom> exclude) {
         Set<ASAtom> keys = new HashSet<>(this.getKeySet());
         keys.removeAll(exclude);
-        keys.removeIf(key -> this.getKey(key).get() == null);
+        keys.removeIf(key -> this.getKey(key).getDirectBase() == null);
         return keys;
     }
 
     @Override
-    public boolean isEquivalentTo(Object o) {
+    public boolean isEquivalentTo(COSBase o) {
         if (this == o) return true;
         if (o == null) return false;
-        if (o instanceof COSObject) {
-            return this.isEquivalentTo(((COSObject) o).get());
+        if (o.isIndirect()) {
+            return isEquivalentTo(o.getDirectBase());
         }
         if (!(o instanceof COSStream)) return false;
         List<COSBasePair> checkedObjects = new LinkedList<>();
@@ -303,12 +303,10 @@ public class COSStream extends COSDictionary {
     }
 
     @Override
-    boolean isEquivalentTo(Object o, List<COSBasePair> checkedObjects) {
+    boolean isEquivalentTo(COSBase o, List<COSBasePair> checkedObjects) {
         if (this == o) return true;
         if (o == null) return false;
-        if (o instanceof COSObject) {
-            return this.isEquivalentTo(((COSObject) o).get(), checkedObjects);
-        }
+
         if (!(o instanceof COSStream)) return false;
         COSStream that = (COSStream) o;
 
@@ -324,7 +322,7 @@ public class COSStream extends COSDictionary {
                 return false;
             }
         } catch (IOException e) {
-            LOGGER.log(Level.FINE, "Exception during comparing decoded streams", e);
+            LOGGER.log(Level.FINE, "Exception during comparing decoded streams");
             return false;
         }
 
@@ -335,17 +333,8 @@ public class COSStream extends COSDictionary {
         if (!thisKeys.equals(thatKeys)) {
             return false;
         }
-        for (ASAtom key : thisKeys) {
-            COSBase thisVal = this.getKey(key).get();
-            COSBase thatVal = that.getKey(key).get();
-            if (thisVal == null && thatVal == null) continue;
-            if (thisVal == null || thatVal == null) return false;
-            if (!thisVal.isEquivalentTo(thatVal, checkedObjects)) {
-                return false;
-            }
-        }
 
-        return true;
+        return isEquivalentKeys(that, thisKeys, checkedObjects);
     }
 
     private static boolean equalsDecodedStreams(ASInputStream first, ASInputStream second) throws IOException {

--- a/src/main/java/org/verapdf/cos/COSString.java
+++ b/src/main/java/org/verapdf/cos/COSString.java
@@ -365,86 +365,22 @@ public class COSString extends COSDirect {
         this.hexCount = hexCount;
     }
 
-    private byte[] getCanonicalBytes() {
-        if (isHex) {
-            return Arrays.copyOf(value, value.length);
-        }
-
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        int i = 0;
-        while (i < value.length) {
-            byte b = value[i];
-            if (b == '\\') {
-                if (i + 1 >= value.length) {
-                    break;
-                }
-                byte next = value[i + 1];
-
-                if (next >= '0' && next <= '7') {
-                    int octal = 0;
-                    int count = 0;
-                    while (i + 1 < value.length && count < 3) {
-                        byte c = value[i + 1];
-                        if (c >= '0' && c <= '7') {
-                            octal = octal * 8 + (c - '0');
-                            i++;
-                            count++;
-                        } else {
-                            break;
-                        }
-                    }
-                    out.write(octal);
-                    continue;
-                }
-
-                if (next == '\r') {
-                    i += 2;
-                    if (i < value.length && value[i] == '\n') {
-                        i++;
-                    }
-                    continue;
-                } else if (next == '\n') {
-                    i += 2;
-                    continue;
-                }
-
-                i++;
-                if (i >= value.length) break;
-                byte esc = value[i];
-                byte replacement;
-                switch (esc) {
-                    case 'n':  replacement = '\n'; break;
-                    case 'r':  replacement = '\r'; break;
-                    case 't':  replacement = '\t'; break;
-                    case 'b':  replacement = '\b'; break;
-                    case 'f':  replacement = '\f'; break;
-                    case '(':  replacement = '(';  break;
-                    case ')':  replacement = ')';  break;
-                    case '\\': replacement = '\\'; break;
-                    default:
-                        replacement = esc;
-                        break;
-                }
-                out.write(replacement);
-            } else {
-                out.write(b);
-            }
-            i++;
-        }
-        return out.toByteArray();
-    }
-
     @Override
-    public boolean isEquivalentTo(Object o) {
+    public boolean isEquivalentTo(COSBase o) {
         if (this == o) return true;
+
+        if (o.isIndirect()) {
+            return isEquivalentTo(o.getDirectBase());
+        }
+
         if (!(o instanceof COSString)) return false;
 
         COSString that = (COSString) o;
 
-        byte[] thisBytes = this.getCanonicalBytes();
-        byte[] thatBytes = that.getCanonicalBytes();
+        String thisString = this.getString();
+        String thatString = that.getString();
 
-        return Arrays.equals(thisBytes, thatBytes);
+        return thisString.equals(thatString);
     }
 
     @Override

--- a/src/main/java/org/verapdf/cos/COSString.java
+++ b/src/main/java/org/verapdf/cos/COSString.java
@@ -368,6 +368,7 @@ public class COSString extends COSDirect {
     @Override
     public boolean isEquivalentTo(COSBase o) {
         if (this == o) return true;
+        if (o == null) return false;
 
         if (o.isIndirect()) {
             return isEquivalentTo(o.getDirectBase());

--- a/src/main/java/org/verapdf/cos/COSString.java
+++ b/src/main/java/org/verapdf/cos/COSString.java
@@ -30,6 +30,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.io.ByteArrayOutputStream;
 
 /**
  * @author Timur Kamalov
@@ -362,6 +363,88 @@ public class COSString extends COSDirect {
 
     public void setHexCount(long hexCount) {
         this.hexCount = hexCount;
+    }
+
+    private byte[] getCanonicalBytes() {
+        if (isHex) {
+            return Arrays.copyOf(value, value.length);
+        }
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int i = 0;
+        while (i < value.length) {
+            byte b = value[i];
+            if (b == '\\') {
+                if (i + 1 >= value.length) {
+                    break;
+                }
+                byte next = value[i + 1];
+
+                if (next >= '0' && next <= '7') {
+                    int octal = 0;
+                    int count = 0;
+                    while (i + 1 < value.length && count < 3) {
+                        byte c = value[i + 1];
+                        if (c >= '0' && c <= '7') {
+                            octal = octal * 8 + (c - '0');
+                            i++;
+                            count++;
+                        } else {
+                            break;
+                        }
+                    }
+                    out.write(octal);
+                    continue;
+                }
+
+                if (next == '\r') {
+                    i += 2;
+                    if (i < value.length && value[i] == '\n') {
+                        i++;
+                    }
+                    continue;
+                } else if (next == '\n') {
+                    i += 2;
+                    continue;
+                }
+
+                i++;
+                if (i >= value.length) break;
+                byte esc = value[i];
+                byte replacement;
+                switch (esc) {
+                    case 'n':  replacement = '\n'; break;
+                    case 'r':  replacement = '\r'; break;
+                    case 't':  replacement = '\t'; break;
+                    case 'b':  replacement = '\b'; break;
+                    case 'f':  replacement = '\f'; break;
+                    case '(':  replacement = '(';  break;
+                    case ')':  replacement = ')';  break;
+                    case '\\': replacement = '\\'; break;
+                    default:
+                        replacement = esc;
+                        break;
+                }
+                out.write(replacement);
+            } else {
+                out.write(b);
+            }
+            i++;
+        }
+        return out.toByteArray();
+    }
+
+    @Override
+    public boolean isEquivalentTo(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof COSString)) return false;
+
+        COSString that = (COSString) o;
+
+        byte[] thisBytes = this.getCanonicalBytes();
+        byte[] thatBytes = that.getCanonicalBytes();
+
+        return Arrays.equals(thisBytes, thatBytes);
     }
 
     @Override


### PR DESCRIPTION
Add support for object comparison from ISO32000-2:2020 Annex J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive equivalence comparison for PDF objects, including arrays, dictionaries, streams, strings, names, booleans, nulls, indirect objects, and numeric values.
  * Numeric comparisons now recognize equivalent integer and decimal representations.
  * Stream comparisons use decoded content while ignoring non-semantic metadata.
  * String comparisons compare decoded values, including common PDF escape sequences and octal representations.
  * Comparisons safely handle nested structures, null values, and cyclic references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->