### PR TITLE
Fix ArrayIndexOutOfBoundsException in getDoubleArrayForBox()

### DIFF
--- a/src/main/java/org/verapdf/pd/PDPage.java
+++ b/src/main/java/org/verapdf/pd/PDPage.java
@@ -160,7 +160,12 @@ public class PDPage extends PDPageTreeNode {
             return null;
         }
         double[] res = new double[4];
-        for (int i = 0; i < array.size(); ++i) {
+        int size = array.size();
+        if (array.size() > 4) {
+            size = 4;
+            LOGGER.log(Level.WARNING, "BBox Array size is greater than 4 in COSArray");
+        }
+        for (int i = 0; i < size; ++i) {
             COSObject obj = array.at(i);
             if (obj.getType().isNumber()) {
                 res[i] = obj.getReal();

--- a/src/main/java/org/verapdf/pd/PDPage.java
+++ b/src/main/java/org/verapdf/pd/PDPage.java
@@ -163,7 +163,7 @@ public class PDPage extends PDPageTreeNode {
         int size = array.size();
         if (array.size() > 4) {
             size = 4;
-            LOGGER.log(Level.WARNING, "BBox Array size is greater than 4 in COSArray");
+            LOGGER.log(Level.WARNING, "Rectangle has more than 4 elements");
         }
         for (int i = 0; i < size; ++i) {
             COSObject obj = array.at(i);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of oversized page bounding-box data by limiting processing to the supported values.
  * Added a warning when additional bounding-box values are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->