### PR TITLE
Fix NPE in clipToMediaBox()

### DIFF
--- a/src/main/java/org/verapdf/pd/PDAnnotation.java
+++ b/src/main/java/org/verapdf/pd/PDAnnotation.java
@@ -285,7 +285,8 @@ public class PDAnnotation extends PDObject {
     public static Boolean isOutsideCropBox(PDPage page, PDAnnotation annotation) {
         double[] cropBox = page.getCropBox();
         double[] rectangle = annotation.getRect();
-        if (rectangle != null && rectangle.length >= 4) {
+        if (rectangle != null && rectangle.length >= 4
+                && cropBox != null && cropBox.length >= 4) {
             return cropBox[1] >= rectangle[3] || cropBox[0] >= rectangle[2]
                     || cropBox[3] <= rectangle[1] || cropBox[2] <= rectangle[0];
         }

--- a/src/main/java/org/verapdf/pd/PDPage.java
+++ b/src/main/java/org/verapdf/pd/PDPage.java
@@ -148,6 +148,9 @@ public class PDPage extends PDPageTreeNode {
     private double[] clipToMediaBox(double[] box) {
         double[] res = new double[4];
         double[] mediaBox = getMediaBox();
+        if (mediaBox == null) {
+            return null;
+        }
         res[0] = Math.max(box[0], mediaBox[0]);
         res[1] = Math.max(box[1], mediaBox[1]);
         res[2] = Math.min(box[2], mediaBox[2]);

--- a/src/main/java/org/verapdf/pd/PDPage.java
+++ b/src/main/java/org/verapdf/pd/PDPage.java
@@ -151,6 +151,9 @@ public class PDPage extends PDPageTreeNode {
         if (mediaBox == null) {
             return box;
         }
+        if (box == null) {
+            return mediaBox;
+        }
         res[0] = Math.max(box[0], mediaBox[0]);
         res[1] = Math.max(box[1], mediaBox[1]);
         res[2] = Math.min(box[2], mediaBox[2]);

--- a/src/main/java/org/verapdf/pd/PDPage.java
+++ b/src/main/java/org/verapdf/pd/PDPage.java
@@ -149,7 +149,7 @@ public class PDPage extends PDPageTreeNode {
         double[] res = new double[4];
         double[] mediaBox = getMediaBox();
         if (mediaBox == null) {
-            return null;
+            return box;
         }
         res[0] = Math.max(box[0], mediaBox[0]);
         res[1] = Math.max(box[1], mediaBox[1]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of annotations with missing or invalid geometry.
  - Prevented incorrect clipping when a page has no media box.
  - Operations now safely return an unavailable result when required page or annotation bounds are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->