### PR TITLE
Fix NPE in getCryptFilters()

### DIFF
--- a/src/main/java/org/verapdf/cos/COSDocument.java
+++ b/src/main/java/org/verapdf/cos/COSDocument.java
@@ -102,9 +102,10 @@ public class COSDocument {
 		initCOSDocument(document);
 	}
 
-	private void initCOSDocument(final PDDocument document) {
+	private void initCOSDocument(final PDDocument document) throws IOException {
 		this.doc = document;
 		this.body = new COSBody();
+        this.reader.checkDocCanBeDecrypted();
 
 		this.header = this.reader.getHeader();
 		this.xref = new COSXRefTable();

--- a/src/main/java/org/verapdf/io/IReader.java
+++ b/src/main/java/org/verapdf/io/IReader.java
@@ -70,4 +70,6 @@ public interface IReader extends Closeable {
 	List<COSObject> getObjectStreamsList();
 
 	int getGreatestKeyNumberFromXref();
+
+    void checkDocCanBeDecrypted() throws IOException;
 }

--- a/src/main/java/org/verapdf/io/Reader.java
+++ b/src/main/java/org/verapdf/io/Reader.java
@@ -145,15 +145,24 @@ public class Reader extends XRefReader {
     @Override
     public void checkDocCanBeDecrypted() throws IOException {
         if (this.parser.isEncrypted() && !docCanBeDecrypted()) {
-            this.getPDFSource().close();
+            InvalidPasswordException failure = new InvalidPasswordException(StringExceptions.ENCRYPTED_PDF);
+            try {
+                this.getPDFSource().close();
+            } catch (IOException e) {
+                failure.addSuppressed(e);
+            }
             if (this.parser.getDocument() != null) {
                 FileResourceHandler handler =
                         this.parser.getDocument().getResourceHandler();
                 if (handler != null) {
-                    handler.close();
+                    try {
+                        handler.close();
+                    }  catch (IOException e) {
+                        failure.addSuppressed(e);
+                    }
                 }
             }
-            throw new InvalidPasswordException(StringExceptions.ENCRYPTED_PDF);
+            throw failure;
         }
     }
 

--- a/src/main/java/org/verapdf/io/Reader.java
+++ b/src/main/java/org/verapdf/io/Reader.java
@@ -142,6 +142,20 @@ public class Reader extends XRefReader {
 		return this.parser.getLinearizationDictionary();
 	}
 
+    @Override
+    public void checkDocCanBeDecrypted() throws IOException {
+        if (this.parser.isEncrypted() && !docCanBeDecrypted()) {
+            this.getPDFSource().close();
+            if (this.parser.getDocument() != null) {
+                FileResourceHandler handler =
+                        this.parser.getDocument().getResourceHandler();
+                if (handler != null) {
+                    handler.close();
+                }
+            }
+            throw new InvalidPasswordException(StringExceptions.ENCRYPTED_PDF);
+        }
+    }
 
 	// PRIVATE METHODS
 	private void init() throws IOException {
@@ -152,17 +166,6 @@ public class Reader extends XRefReader {
 			this.parser.getXRefInfo(infos);
 			setXRefInfo(infos);
 
-			if (this.parser.isEncrypted() && !docCanBeDecrypted()) {
-				this.getPDFSource().close();
-				if (this.parser.getDocument() != null) {
-					FileResourceHandler handler =
-							this.parser.getDocument().getResourceHandler();
-					if (handler != null) {
-						handler.close();
-					}
-				}
-				throw new InvalidPasswordException(StringExceptions.ENCRYPTED_PDF);
-			}
 		} catch (IOException e) {	// If exception is thrown in init() someone
 			// should close document stream
 			this.parser.closeInputStream();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved encrypted-document handling during document loading.
  - Invalid passwords now trigger the appropriate error and safely close related resources.
  - Prevented errors when accessing document objects before internal content is available.
- **Reliability**
  - Document initialization now reports decryption and input/output failures more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->