### PR TITLE
Add methods to get Ascent/Descent from CharProc for Type3 fonts

### DIFF
--- a/src/main/java/org/verapdf/pd/font/type3/PDType3Font.java
+++ b/src/main/java/org/verapdf/pd/font/type3/PDType3Font.java
@@ -157,4 +157,30 @@ public class PDType3Font extends PDSimpleFont {
     public boolean glyphIsPresent(int code) {
         return containsCharString(code);
     }
+
+    public float getAscentFromProgram(int code) {
+        COSObject charProc = getCharProc(code);
+        if (charProc.getType() == COSObjType.COS_STREAM) {
+            try (Type3CharProcParser parser = new Type3CharProcParser(charProc.getData(COSStream.FilterFlags.DECODE))) {
+                parser.parse();
+                return (float) parser.getAscent();
+            } catch (IOException e) {
+                LOGGER.log(Level.FINE, "Can't get ascent from type 3 char proc");
+            }
+        }
+        return 0;
+    }
+
+    public float getDescentFromProgram(int code) {
+        COSObject charProc = getCharProc(code);
+        if (charProc.getType() == COSObjType.COS_STREAM) {
+            try (Type3CharProcParser parser = new Type3CharProcParser(charProc.getData(COSStream.FilterFlags.DECODE))) {
+                parser.parse();
+                return (float) parser.getDescent();
+            } catch (IOException e) {
+                LOGGER.log(Level.FINE, "Can't get descent from type 3 char proc");
+            }
+        }
+        return 0;
+    }
 }

--- a/src/main/java/org/verapdf/pd/font/type3/PDType3Font.java
+++ b/src/main/java/org/verapdf/pd/font/type3/PDType3Font.java
@@ -158,29 +158,29 @@ public class PDType3Font extends PDSimpleFont {
         return containsCharString(code);
     }
 
-    public float getAscentFromProgram(int code) {
+    public Double getAscentFromProgram(int code) {
         COSObject charProc = getCharProc(code);
         if (charProc.getType() == COSObjType.COS_STREAM) {
             try (Type3CharProcParser parser = new Type3CharProcParser(charProc.getData(COSStream.FilterFlags.DECODE))) {
                 parser.parse();
-                return (float) parser.getAscent();
+                return parser.getAscent();
             } catch (IOException e) {
                 LOGGER.log(Level.FINE, "Can't get ascent from type 3 char proc");
             }
         }
-        return 0;
+        return null;
     }
 
-    public float getDescentFromProgram(int code) {
+    public Double getDescentFromProgram(int code) {
         COSObject charProc = getCharProc(code);
         if (charProc.getType() == COSObjType.COS_STREAM) {
             try (Type3CharProcParser parser = new Type3CharProcParser(charProc.getData(COSStream.FilterFlags.DECODE))) {
                 parser.parse();
-                return (float) parser.getDescent();
+                return parser.getDescent();
             } catch (IOException e) {
                 LOGGER.log(Level.FINE, "Can't get descent from type 3 char proc");
             }
         }
-        return 0;
+        return null;
     }
 }

--- a/src/main/java/org/verapdf/pd/font/type3/Type3CharProcParser.java
+++ b/src/main/java/org/verapdf/pd/font/type3/Type3CharProcParser.java
@@ -34,6 +34,8 @@ import java.io.IOException;
 public class Type3CharProcParser extends NotSeekableBaseParser {
 
     private double width = -1;
+    private double ascent = 0;
+    private double descent = 0;
     private static final String D0 = "d0";
     private static final String D1 = "d1";
 
@@ -64,12 +66,20 @@ public class Type3CharProcParser extends NotSeekableBaseParser {
         }   // else ll_x
 
         nextToken();    // ll_y
+        if (getToken().type == Token.Type.TT_INTEGER || getToken().type == Token.Type.TT_REAL) {
+            this.descent = getToken().real;
+        }
         nextToken();    // ur_x
         nextToken();    // ur_y
+        if (getToken().type == Token.Type.TT_INTEGER || getToken().type == Token.Type.TT_REAL) {
+            this.ascent = getToken().real;
+        }
         nextToken();    // d1
 
         if (getToken().type != Token.Type.TT_KEYWORD || !getToken().getValue().equals(D1)) {    // stream is corrupted
             this.width = -1;
+            this.ascent = 0;
+            this.descent = 0;
             throw new IOException("Can't parse type 3 char proc");
         }
     }
@@ -80,5 +90,13 @@ public class Type3CharProcParser extends NotSeekableBaseParser {
      */
     public double getWidth() {
         return width;
+    }
+
+    public double getAscent() {
+        return ascent;
+    }
+
+    public double getDescent() {
+        return descent;
     }
 }

--- a/src/main/java/org/verapdf/pd/font/type3/Type3CharProcParser.java
+++ b/src/main/java/org/verapdf/pd/font/type3/Type3CharProcParser.java
@@ -34,8 +34,8 @@ import java.io.IOException;
 public class Type3CharProcParser extends NotSeekableBaseParser {
 
     private double width = -1;
-    private double ascent = 0;
-    private double descent = 0;
+    private Double ascent;
+    private Double descent;
     private static final String D0 = "d0";
     private static final String D1 = "d1";
 
@@ -78,8 +78,8 @@ public class Type3CharProcParser extends NotSeekableBaseParser {
 
         if (getToken().type != Token.Type.TT_KEYWORD || !getToken().getValue().equals(D1)) {    // stream is corrupted
             this.width = -1;
-            this.ascent = 0;
-            this.descent = 0;
+            this.ascent = null;
+            this.descent = null;
             throw new IOException("Can't parse type 3 char proc");
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving glyph ascent and descent metrics from Type 3 font character procedures.
  * Exposed parsed vertical font metrics for improved font measurement and rendering behavior.

* **Bug Fixes**
  * Improved handling of unavailable or unreadable character procedures by returning unavailable metric values instead of misleading zero values.
  * Preserved existing error logging when character procedure parsing fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->