### PR TITLE
Fix misparse when FontMatrix directly follows ROS in CFF font TopDict

### DIFF
--- a/src/main/java/org/verapdf/pd/font/cff/CFFFontBaseParser.java
+++ b/src/main/java/org/verapdf/pd/font/cff/CFFFontBaseParser.java
@@ -142,7 +142,8 @@ class CFFFontBaseParser extends CFFFileBaseParser {
                                 case 7:     // FontMatrix
                                     fontMatrix = new float[6];
                                     for (int i = 0; i < 6; ++i) {
-                                        fontMatrix[i] = this.stack.get(i).getReal();
+                                        fontMatrix[i] =
+                                                this.stack.get(this.stack.size() - 6 + i).getReal();
                                     }
                                     this.stack.clear();
                                     break;
@@ -153,6 +154,7 @@ class CFFFontBaseParser extends CFFFileBaseParser {
                                     break;
                                 case 30:
                                     this.containsROS = true;
+                                    this.stack.clear();
                                     break;
                                 default:
                                     readTopDictTwoByteOps(next);


### PR DESCRIPTION
The current verification for font glyph widths matching PDF glyph widths in  veraPDF fails for certain CFF based fonts because veraPDF parses the FontMatrix incorrectly when it directly follows the `ROS` operator in the CFF TopDict.

For an affected example font, see Pennstander where this is the cause of https://github.com/juliusross1/Pennstander/issues/29 (ignore the LLM hallucinations in the discussion, they are unrelated to the actual problem).

<details>
<summary>
More details description of caused issue
</summary>

The CFF font's TopDict in an example PDF as visualized by `tx` starts with
```
  395 396 0 ROS
  1E-3 0 0 1E-3 0 0 FontMatrix
```
and validating the same PDF with veraPDF shows errors including 
```
          <check status="failed">
              <context>root/document[0]/pages[0](29 0 obj PDPage)/contentStream[0](30 0 obj PDSemanticContentStream)/operators[7]/usedGlyphs[10](RJSBXK+Pennstander-Regular RJSBXK+Pennstander-Regular 570 0 283039401 0 true)</context>
              <errorMessage>Glyph width 472024992 in the embedded font program is not consistent with the Widths entry of the font dictionary (value 1195)</errorMessage>
            </check>
```
Note that 472024992/1195 is approximately 395000. This is because VeraPDF scales the width by the font matrix, but for the font matrix the 395 operator from ROS is picked up instead of the 1E-3 which is supposed to go to the FontMatrix.
</details>

The cause is two-fold: When CFFFontBaseParser reads `12 30` (aka. ROS), it sets a flag but does not clear the stack, so the operators from `ROS` stay on the stack. This is different from all other operators which do clear the stack after they are done.

For most operators additional stack elements do not make a difference since parameters are read form the top of the stack, but `12 7` (aka. FontMatrix) reads it's 6 parameters from the stack starting with index 0 (the bottom), so it picks up any unexpected stack elements.

Changing either of these things would fix the issue, but I suggest fixing both: Clearing the stack after `ROS` is better for consistency and avoids unexpected stack states and reading the font matrix from the top of the stack is also more consistent and also better matches the specification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CFF font parsing when processing FontMatrix values.
  * Ensured operand data is cleared correctly after handling ROS metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->