### PR TITLE
Update getLength in PDEncryprion according to specification

### DIFF
--- a/src/main/java/org/verapdf/pd/encryption/PDEncryption.java
+++ b/src/main/java/org/verapdf/pd/encryption/PDEncryption.java
@@ -95,7 +95,9 @@ public class PDEncryption extends PDObject {
      */
     public int getLength() {
         int v = getV();
-        if (v == 4) {
+        if (v == 1) {
+            return DEFAULT_LENGTH;
+        } else if (v == 4) {
             return DEFAULT_V4_LENGTH;
         } else if (v == 5) {
             return DEFAULT_V5_LENGTH;

--- a/src/main/java/org/verapdf/pd/encryption/PDEncryption.java
+++ b/src/main/java/org/verapdf/pd/encryption/PDEncryption.java
@@ -43,6 +43,8 @@ public class PDEncryption extends PDObject {
 
     private static final boolean DEFAULT_ENCRYPT_METADATA = true;
     private static final int DEFAULT_LENGTH = 40;
+    private static final int DEFAULT_V4_LENGTH = 128;
+    private static final int DEFAULT_V5_LENGTH = 256;
     private static final int DEFAULT_V = 0;
     private Map<ASAtom, PDCryptFilter> cryptFilters;
 
@@ -92,6 +94,12 @@ public class PDEncryption extends PDObject {
      * @return the length of the encryption key, in bits.
      */
     public int getLength() {
+        int v = getV();
+        if (v == 4) {
+            return DEFAULT_V4_LENGTH;
+        } else if (v == 5) {
+            return DEFAULT_V5_LENGTH;
+        }
         return getIntWithDefault(ASAtom.LENGTH, DEFAULT_LENGTH);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF encryption handling by applying the correct default key lengths for encryption algorithms V4 and V5.
  * Preserved existing behavior for other encryption configurations, including dictionary-defined and legacy defaults.
  * Enhanced compatibility when opening and processing encrypted PDF documents that use newer encryption standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->