### PR TITLE
Stop throwing NPE on Type3 char proc metrics when no glyph bbox is declared

### DIFF
--- a/src/main/java/org/verapdf/pd/font/type3/PDType3Font.java
+++ b/src/main/java/org/verapdf/pd/font/type3/PDType3Font.java
@@ -163,7 +163,7 @@ public class PDType3Font extends PDSimpleFont {
         if (charProc.getType() == COSObjType.COS_STREAM) {
             try (Type3CharProcParser parser = new Type3CharProcParser(charProc.getData(COSStream.FilterFlags.DECODE))) {
                 parser.parse();
-                return parser.getAscent();
+                return parser.getAscentOrNull();
             } catch (IOException e) {
                 LOGGER.log(Level.FINE, "Can't get ascent from type 3 char proc");
             }
@@ -176,7 +176,7 @@ public class PDType3Font extends PDSimpleFont {
         if (charProc.getType() == COSObjType.COS_STREAM) {
             try (Type3CharProcParser parser = new Type3CharProcParser(charProc.getData(COSStream.FilterFlags.DECODE))) {
                 parser.parse();
-                return parser.getDescent();
+                return parser.getDescentOrNull();
             } catch (IOException e) {
                 LOGGER.log(Level.FINE, "Can't get descent from type 3 char proc");
             }

--- a/src/main/java/org/verapdf/pd/font/type3/Type3CharProcParser.java
+++ b/src/main/java/org/verapdf/pd/font/type3/Type3CharProcParser.java
@@ -92,11 +92,45 @@ public class Type3CharProcParser extends NotSeekableBaseParser {
         return width;
     }
 
+    /**
+     * @return ascent of the glyph presented by given char proc, or 0 if the char
+     * proc declares no glyph bounding box.
+     * @deprecated a char proc that begins with the d0 operator specifies the
+     * glyph width only (ISO 32000-1, 9.6.5.3) and declares no glyph bounding
+     * box, so its ascent is undefined rather than 0. This method cannot express
+     * that; use {@link #getAscentOrNull()} instead.
+     */
+    @Deprecated
     public double getAscent() {
+        return ascent == null ? 0 : ascent;
+    }
+
+    /**
+     * @return descent of the glyph presented by given char proc, or 0 if the
+     * char proc declares no glyph bounding box.
+     * @deprecated undefined descent cannot be distinguished from 0; use
+     * {@link #getDescentOrNull()} instead. See {@link #getAscent()}.
+     */
+    @Deprecated
+    public double getDescent() {
+        return descent == null ? 0 : descent;
+    }
+
+    /**
+     * @return ascent of the glyph presented by given char proc, or null if the
+     * char proc declares no glyph bounding box. A char proc that begins with
+     * the d0 operator specifies the glyph width only (ISO 32000-1, 9.6.5.3),
+     * so its ascent is undefined rather than 0.
+     */
+    public Double getAscentOrNull() {
         return ascent;
     }
 
-    public double getDescent() {
+    /**
+     * @return descent of the glyph presented by given char proc, or null if the
+     * char proc declares no glyph bounding box. See {@link #getAscentOrNull()}.
+     */
+    public Double getDescentOrNull() {
         return descent;
     }
 }

--- a/src/test/java/org/verapdf/pd/font/type3/Type3CharProcParserTest.java
+++ b/src/test/java/org/verapdf/pd/font/type3/Type3CharProcParserTest.java
@@ -1,0 +1,102 @@
+/*
+ * This file is part of veraPDF Parser, a module of the veraPDF project.
+ * Copyright (c) 2015-2026, veraPDF Consortium <info@verapdf.org>
+ * All rights reserved.
+ *
+ * veraPDF Parser is free software: you can redistribute it and/or modify
+ * it under the terms of either:
+ *
+ * The GNU General public license GPLv3+.
+ * You should have received a copy of the GNU General Public License
+ * along with veraPDF Parser as the LICENSE.GPL file in the root of the source
+ * tree.  If not, see http://www.gnu.org/licenses/ or
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * The Mozilla Public License MPLv2+.
+ * You should have received a copy of the Mozilla Public License along with
+ * veraPDF Parser as the LICENSE.MPL file in the root of the source tree.
+ * If a copy of the MPL was not distributed with this file, you can obtain one at
+ * http://mozilla.org/MPL/2.0/.
+ */
+package org.verapdf.pd.font.type3;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.verapdf.as.io.ASMemoryInStream;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+class Type3CharProcParserTest {
+
+    private static final double EPSILON = 1.0e-6;
+
+    private static Type3CharProcParser parse(String charProc) throws IOException {
+        Type3CharProcParser parser = new Type3CharProcParser(
+                new ASMemoryInStream(charProc.getBytes(StandardCharsets.ISO_8859_1)));
+        parser.parse();
+        return parser;
+    }
+
+    /**
+     * A char proc that starts with d1 declares a glyph bounding box, so both
+     * metrics are available.
+     */
+    @Test
+    void d1CharProcReportsMetrics() throws IOException {
+        try (Type3CharProcParser parser = parse("1000 0 0 -200 750 800 d1\n")) {
+            Assertions.assertEquals(1000, parser.getWidth(), EPSILON);
+            Assertions.assertEquals(800, parser.getAscentOrNull(), EPSILON);
+            Assertions.assertEquals(-200, parser.getDescentOrNull(), EPSILON);
+        }
+    }
+
+    /**
+     * A char proc that starts with d0 specifies the glyph width only
+     * (ISO 32000-1, 9.6.5.3). Its ascent and descent are undefined, so they
+     * must be reported as null rather than defaulted to zero: a zero descent
+     * would win a minimum comparison against the real descents of the other
+     * glyphs in the same font.
+     */
+    @Test
+    void d0CharProcReportsNullMetrics() throws IOException {
+        try (Type3CharProcParser parser = parse("1000 0 d0\n")) {
+            Assertions.assertEquals(1000, parser.getWidth(), EPSILON);
+            Assertions.assertNull(parser.getAscentOrNull());
+            Assertions.assertNull(parser.getDescentOrNull());
+        }
+    }
+
+    /**
+     * The pre-existing primitive getters keep their released signatures and
+     * substitute 0 for an undefined metric instead of throwing.
+     */
+    @Test
+    @SuppressWarnings("deprecation")
+    void deprecatedPrimitiveGettersSubstituteZeroForUndefinedMetrics() throws IOException {
+        try (Type3CharProcParser parser = parse("1000 0 d0\n")) {
+            Assertions.assertEquals(0, parser.getAscent(), EPSILON);
+            Assertions.assertEquals(0, parser.getDescent(), EPSILON);
+        }
+        try (Type3CharProcParser parser = parse("1000 0 0 -200 750 800 d1\n")) {
+            Assertions.assertEquals(800, parser.getAscent(), EPSILON);
+            Assertions.assertEquals(-200, parser.getDescent(), EPSILON);
+        }
+    }
+
+    /**
+     * A char proc whose bounding box is not terminated by d1 is corrupted;
+     * parse() reports it and leaves no metrics behind.
+     */
+    @Test
+    void corruptedCharProcThrowsAndClearsMetrics() throws IOException {
+        Type3CharProcParser parser = new Type3CharProcParser(
+                new ASMemoryInStream("1000 0 0 -200 750 800 xx\n".getBytes(StandardCharsets.ISO_8859_1)));
+        try (Type3CharProcParser closeable = parser) {
+            Assertions.assertThrows(IOException.class, closeable::parse);
+        }
+        Assertions.assertEquals(-1, parser.getWidth(), EPSILON);
+        Assertions.assertNull(parser.getAscentOrNull());
+        Assertions.assertNull(parser.getDescentOrNull());
+    }
+}


### PR DESCRIPTION
## Problem

`Type3CharProcParser.getAscent()` and `getDescent()` return primitive `double`, but the backing `ascent` / `descent` fields are `Double` and legitimately stay `null`.

A char proc whose first operator is `d0` specifies the glyph width only (ISO 32000-1, 9.6.5.3) and declares no glyph bounding box, so `parse()` returns early with both fields unset:

```java
nextToken();
if (getToken().type == Token.Type.TT_KEYWORD && getToken().getValue().equals(D0)) {
    return;                     // ascent / descent stay null
}
```

Reading either metric for such a glyph throws `NullPointerException` while unboxing:

```
java.lang.NullPointerException: Cannot invoke "java.lang.Double.doubleValue()" because "this.ascent" is null
	at org.verapdf.pd.font.type3.Type3CharProcParser.getAscent(Type3CharProcParser.java:96)
	at org.verapdf.pd.font.type3.PDType3Font.getAscentFromProgram(PDType3Font.java:166)
```

A single `d0` glyph anywhere in a Type 3 font is enough to trigger it.

## Fix

Both getters shipped in v1.31.48, so their descriptors are left alone to stay binary compatible:

| Method | Behaviour |
|---|---|
| `double getAscent()` / `double getDescent()` | Unchanged signature. Substitute `0` for an undefined metric instead of throwing. Deprecated. |
| `Double getAscentOrNull()` / `Double getDescentOrNull()` | New. Distinguish "no glyph bounding box" from a real `0`. |

`PDType3Font.getAscentFromProgram` / `getDescentFromProgram` now read the nullable accessors. Without that the unboxing NPE would simply move up one frame — those methods are declared `Double` and already return `null` when the char proc cannot be parsed.

The consumer in wcag-validation `ChunkParser` already guards with `if (glyphAscent != null)` before aggregating, so no change is needed there.

## Why the nullable accessors matter

`0` keeps the deprecated path running, but it is not a correct metric. Ascent and descent are aggregated by maximum and minimum across the glyphs of a font, so a `0` descent wins the minimum comparison against the real negative descents of the surrounding glyphs and silently flattens the text line box — a quality regression that is harder to notice than a crash. `d0` genuinely means "no bounding box", so `null` is the accurate value for callers that can handle it.

Deriving a substitute from `/FontDescriptor` or `/FontBBox` was considered and rejected: it invents information the char proc does not declare, and the affected documents are exactly the ones whose font metadata is unreliable.

## Tests

Adds `Type3CharProcParserTest`:

| Case | Expectation |
|---|---|
| `d1` char proc | width, ascent and descent all reported |
| `d0` char proc | width reported, nullable accessors return `null` |
| `d0` and `d1` via deprecated getters | `0` for undefined, real value otherwise; never throws |
| bbox not terminated by `d1` | `IOException`, metrics cleared |

The `d0` case reproduces the `NullPointerException` against the original getters (verified by reverting: 2 errors) and passes with this change.

Full module suite: 375 tests, 0 failures, 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Type 3 font metric handling when character procedures define width without a bounding box.
  * Preserved undefined ascent and descent values instead of treating them as valid zero metrics.
  * Improved handling of malformed character procedures by clearing invalid metrics after parsing errors.

* **API Updates**
  * Added nullable accessors for ascent and descent metrics.
  * Deprecated legacy metric accessors, which now return zero when values are undefined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->