### PR TITLE
Allow an upper bound on the number of indirect objects

### DIFF
--- a/src/main/java/org/verapdf/cos/COSDocument.java
+++ b/src/main/java/org/verapdf/cos/COSDocument.java
@@ -50,6 +50,8 @@ public class COSDocument {
 
 	private static final Logger LOGGER = Logger.getLogger(COSDocument.class.getCanonicalName());
 
+	private static volatile int maxNumberOfObjects = -1;
+
 	private PDDocument doc;
 	private IReader reader;
 	private COSHeader header;
@@ -136,7 +138,39 @@ public class COSDocument {
 		this.header.setHeader(header);
 	}
 
+	/**
+	 * Sets an upper bound on the number of indirect objects the document may declare in its
+	 * cross-reference table. Enumerating the objects materialises one entry per key, so a document that
+	 * declares an extreme number of objects (a small compressed input can, via an object stream) can
+	 * exhaust the heap; with a bound set it is rejected with a {@link VeraPDFParserException} before the
+	 * objects are materialised, instead of failing with an OutOfMemoryError. A negative value (the
+	 * default) removes the bound, keeping the historical behaviour.
+	 *
+	 * @param max maximum number of indirect objects, or a negative value for no bound
+	 */
+	public static void setMaxNumberOfObjects(int max) {
+		maxNumberOfObjects = max;
+	}
+
+	/**
+	 * @return the current upper bound on the number of indirect objects, or {@code -1} if unbounded
+	 */
+	public static int getMaxNumberOfObjects() {
+		return maxNumberOfObjects;
+	}
+
+	private void checkObjectCountLimit() {
+		if (maxNumberOfObjects >= 0) {
+			int declared = this.xref.getAllKeys().size();
+			if (declared > maxNumberOfObjects) {
+				throw new VeraPDFParserException("Number of indirect objects (" + declared
+						+ ") exceeds the configured maximum of " + maxNumberOfObjects);
+			}
+		}
+	}
+
 	public List<COSObject> getObjects() {
+		checkObjectCountLimit();
 		List<COSObject> result = new ArrayList<>();
 		for (COSKey key : this.xref.getAllKeys()) {
 			COSObject obj = this.body.get(key);
@@ -161,6 +195,7 @@ public class COSDocument {
 	}
 
 	public List<COSObject> getObjectsByType(ASAtom type) {
+		checkObjectCountLimit();
 		List<COSObject> result = new ArrayList<>();
 		for (COSKey key : this.xref.getAllKeys()) {
 			COSObject obj = this.body.get(key);
@@ -192,6 +227,7 @@ public class COSDocument {
 	}
 
 	public Map<COSKey, COSObject> getObjectsMap() {
+		checkObjectCountLimit();
 		Map<COSKey, COSObject> result = new HashMap<>();
 		for (COSKey key : this.xref.getAllKeys()) {
 			COSObject obj = this.body.get(key);


### PR DESCRIPTION
### Summary

Enumerating a document's objects (`getObjects`, `getObjectsByType`, `getObjectsMap`) materialises one entry
per cross-reference key. A small compressed input can declare an extreme number of objects through an
object stream, so enumeration can exhaust the heap and fail with an `OutOfMemoryError`, which is not
recoverable and affects the whole process.

### Changes

- `COSDocument.setMaxNumberOfObjects(int)` / `getMaxNumberOfObjects()` set an optional upper bound on the
  number of indirect objects. When a bound is set, a document that declares more indirect objects than the
  bound is rejected up front with a `VeraPDFParserException`, before the objects are materialised. The
  check uses the cross-reference key count, so it costs nothing when no bound is set.

### Backward compatibility

Default is unbounded, so behaviour is unchanged unless a caller opts in. Java 8 compatible, and all
existing parser tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable limit for the number of indirect objects declared in a document.
  * Documents exceeding the configured limit now fail with a parser error before objects are materialized.
  * The limit defaults to unlimited and can be read or updated through the document configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->